### PR TITLE
i128 - use alternative override method as the decorator pattern was ignored

### DIFF
--- a/app/search_builders/hyrax/filter_by_type_decorator.rb
+++ b/app/search_builders/hyrax/filter_by_type_decorator.rb
@@ -1,16 +1,12 @@
 # frozen_string_literal: true
 
 # OVERRIDE HYRAX 3.4.1 to remove Attachment model from search results
-module Hyrax
-  module FilterByTypeDecorator
-    # Override this method if you want to filter for a different set of models.
-    # @return [Array<Class>] a list of classes to include
-    def models
-      the_models = super
-      return the_models unless ['catalog', 'hyrax/my/works'].include?(blacklight_params[:controller])
-      the_models - [Attachment]
-    end
+Hyrax::FilterByType.module_eval do
+  # Override this method if you want to filter for a different set of models.
+  # @return [Array<Class>] a list of classes to include
+  def models
+    the_models = work_classes + collection_classes
+    return the_models unless ['catalog', 'hyrax/my/works'].include?(blacklight_params[:controller])
+    the_models - [Attachment]
   end
 end
-
-Hyrax::FilterByType.prepend(Hyrax::FilterByTypeDecorator)


### PR DESCRIPTION
Fixes #128 

Re-write override to use module_eval pattern instead of the decorator pattern. There is a known issue with decorator files being ignored in this project. 

The content of this MR filters out Attachment model types from the catalog search and works index page, so that it behaves similarly to a file set even though it's a work type. The logic was already [approved](https://gitlab.com/notch8/utk-hyku/-/merge_requests/148) before the github move. 

Overrides Hyrax::FilterByType 3.4.1 #[models](https://github.com/samvera/hyrax/blob/main/app/search_builders/hyrax/filter_by_type.rb#L28-L30) method

Changes proposed in this pull request:
* Decorator pattern => module_eval

