### PR TITLE
remove-redis-pw-value-not-needed

### DIFF
--- a/ops/staging-deploy.tmpl.yaml
+++ b/ops/staging-deploy.tmpl.yaml
@@ -122,8 +122,6 @@ extraEnvVars: &envVars
     value: "true"
   - name: REDIS_HOST
     value: utk-hyku-staging-redis-master
-  - name: REDIS_PASSWORD
-    value: $REDIS_PASSWORD
   - name: REDIS_URL
     value: redis://:$REDIS_PASSWORD@utk-hyku-staging-redis-master:6379/utk-hyku
   - name: HYKU_ACTIVE_JOB_QUEUE_URL


### PR DESCRIPTION
Remove the redis password value and env variable as cable just needs redis url, when the redis password is present it reconfigures the redis_url in cable.yml