### PR TITLE
127 - loosen the check for rdf_type

### DIFF
--- a/app/jobs/create_derivatives_job_decorator.rb
+++ b/app/jobs/create_derivatives_job_decorator.rb
@@ -3,7 +3,7 @@
 # OVERRIDE HYRAX 3.4.1 to skip derivative job if rdf_type is "pcdm-muse:PreservationFile"
 module Hyrax
   module CreateDerivativesJobDecorator
-    PRESERVATION_FILE = "PreservationFile"
+    PRESERVATION_FILE = "PreservationFile".downcase
 
     # @param [FileSet] file_set
     # @param [String] file_id identifier for a Hydra::PCDM::File
@@ -11,7 +11,7 @@ module Hyrax
     def perform(file_set, file_id, filepath = nil)
       return if file_set.video? && !Hyrax.config.enable_ffmpeg
       # OVERRIDE HYRAX 3.4.1 to skip derivative job if rdf_type is "pcdm-muse:PreservationFile"
-      return if file_set.rdf_type.include? PRESERVATION_FILE
+      return if file_set.rdf_type.downcase.include? PRESERVATION_FILE
 
       # Ensure a fresh copy of the repo file's latest version is being worked on, if no filepath is directly provided
       unless filepath && File.exist?(filepath)

--- a/app/jobs/create_derivatives_job_decorator.rb
+++ b/app/jobs/create_derivatives_job_decorator.rb
@@ -3,7 +3,7 @@
 # OVERRIDE HYRAX 3.4.1 to skip derivative job if rdf_type is "pcdm-muse:PreservationFile"
 module Hyrax
   module CreateDerivativesJobDecorator
-    PRESERVATION_FILE = "pcdm-muse:PreservationFile"
+    PRESERVATION_FILE = "PreservationFile"
 
     # @param [FileSet] file_set
     # @param [String] file_id identifier for a Hydra::PCDM::File
@@ -11,7 +11,7 @@ module Hyrax
     def perform(file_set, file_id, filepath = nil)
       return if file_set.video? && !Hyrax.config.enable_ffmpeg
       # OVERRIDE HYRAX 3.4.1 to skip derivative job if rdf_type is "pcdm-muse:PreservationFile"
-      return if file_set.rdf_type == PRESERVATION_FILE
+      return if file_set.rdf_type.include? PRESERVATION_FILE
 
       # Ensure a fresh copy of the repo file's latest version is being worked on, if no filepath is directly provided
       unless filepath && File.exist?(filepath)


### PR DESCRIPTION
sometimes rdf_type will be http://pcdm.org/use#PreservationFile. 

So this change loosens the strict comparison. Now it any string includes PreservationFile we will skip creating derivatives.