### PR TITLE
149 - updated and added additional metadata per client's spreasheet a…

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -96,7 +96,7 @@ class CatalogController < ApplicationController
     config.add_index_field 'lease_expiration_date_dtsi', label: "Lease expiration date", helper_method: :human_readable_date
 
     # collection metadata
-    config.add_index_field 'collection_link', label: 'Publication Place'
+    config.add_index_field 'collection_link', label: 'Collection Link'
     config.add_index_field 'date_created_d_tesim', label: 'Machine Readable Creation Date'
     config.add_index_field 'date_issued_tesim', label: 'Date Issued'
     config.add_index_field 'date_issued_d_tesim', label: 'Machine Readable Publication Date'
@@ -104,6 +104,7 @@ class CatalogController < ApplicationController
     config.add_index_field 'form_tesim', label: 'Form'
     config.add_index_field 'publication_place_tesim', label: 'Publication Place'
     config.add_index_field 'repository_tesim', label: 'Repository'
+    config.add_index_field 'rights_notes_tesim', label: 'Rights Notes'
     config.add_index_field 'spatial_tesim', label: 'Spatial Coverage'
     config.add_index_field 'utk_contributor_tesim', label: 'Local Contributor'
     config.add_index_field 'utk_creator_tesim', label: 'Local Creator'
@@ -131,12 +132,14 @@ class CatalogController < ApplicationController
     config.add_show_field 'extent_tesim'
 
     # add collection show fields
+    config.add_show_field 'collection_link', label: 'Collection Link'
     config.add_show_field 'date_created_d_tesim', label: 'Machine Readable Creation Date'
     config.add_show_field 'date_issued_tesim', label: 'Date Issued'
     config.add_show_field 'date_issued_d_tesim', label: 'Machine Readable Publication Date'
     config.add_show_field 'form_tesim', label: 'Form'
     config.add_show_field 'publication_place_tesim', label: 'Publication Place'
     config.add_show_field 'repository_tesim', label: 'Repository'
+    config.add_show_field 'rights_notes_tesim', label: 'Rights Notes'
     config.add_show_field 'spatial_tesim', label: 'Spatial Coverage'
     config.add_show_field 'utk_contributor_tesim', label: 'Local Contributor'
     config.add_show_field 'utk_creator_tesim', label: 'Local Creator'

--- a/app/forms/hyrax/forms/collection_form_decorator.rb
+++ b/app/forms/hyrax/forms/collection_form_decorator.rb
@@ -3,29 +3,33 @@
 module Hyrax
   module Forms
     module CollectionFormDecorator
+      # Terms that appear above the accordion
+      def primary_terms
+        [:title, :abstract]
+      end
+
       def secondary_terms
         %i[
-          alternative_title
-          creator
-          contributor
-          keyword
-          license
-          publisher
-          date_created
-          subject
-          language
-          identifier
           based_near
-          related_url
-          resource_type
+          contributor
+          creator
+          date_created
           date_created_d
           date_issued
           date_issued_d
           extent
           form
+          identifier
+          keyword
+          language
           publication_place
+          publisher
+          related_url
           repository
+          resource_type
+          rights_notes
           spatial
+          subject
           utk_contributor
           utk_creator
           utk_publisher
@@ -37,6 +41,7 @@ end
 
 # adds custom terms to `self.terms`
 Hyrax::Forms::CollectionForm.terms += %i[
+  abstract
   date_created_d
   date_issued
   date_issued_d
@@ -44,6 +49,7 @@ Hyrax::Forms::CollectionForm.terms += %i[
   form
   publication_place
   repository
+  rights_notes
   spatial
   utk_contributor
   utk_creator utk_publisher

--- a/app/forms/hyrax/forms/collection_form_decorator.rb
+++ b/app/forms/hyrax/forms/collection_form_decorator.rb
@@ -5,7 +5,7 @@ module Hyrax
     module CollectionFormDecorator
       # Terms that appear above the accordion
       def primary_terms
-        [:title, :abstract]
+        %i[title abstract]
       end
 
       def secondary_terms

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -42,7 +42,7 @@ class Collection < ActiveFedora::Base
   end
 
   property :form,
-           predicate: ::RDF::URI('http://www.europeana.eu/schemas/edm/hasType'),
+           predicate: ::RDF::URI('http://purl.org/dc/terms/format'),
            multiple: true do |index|
     index.as :displayable, :stored_searchable
   end

--- a/app/presenters/hyrax/collection_presenter.rb
+++ b/app/presenters/hyrax/collection_presenter.rb
@@ -9,29 +9,30 @@ require_dependency Hyrax::Engine.root.join('app', 'presenters', 'hyrax', 'collec
 Hyrax::CollectionPresenter.class_eval do
   # OVERRIDE Hyrax - removed size
   delegate :collection_link, :date_created_d, :date_issued, :date_issued_d,
-           :extent, :form, :publication_place, :repository, :spatial,
+           :extent, :form, :publication_place, :repository, :rights_notes, :spatial,
            :utk_contributor, :utk_creator, :utk_publisher, to: :solr_document
 
   def self.terms
     %i[ total_items
-        resource_type
-        creator contributor
-        keyword license
-        publisher
-        date_created
-        subject language
-        identifier
         based_near
-        related_url
+        collection_link
+        creator contributor
+        date_created
         date_created_d
         date_issued
         date_issued_d
         extent
         form
-        collection_link
+        identifier
+        keyword license
         publication_place
+        publisher
+        related_url
         repository
+        resource_type
+        rights_notes
         spatial
+        subject language
         utk_contributor
         utk_creator
         utk_publisher ]

--- a/app/presenters/hyrax/collection_presenter.rb
+++ b/app/presenters/hyrax/collection_presenter.rb
@@ -8,12 +8,13 @@ require_dependency Hyrax::Engine.root.join('app', 'presenters', 'hyrax', 'collec
 
 Hyrax::CollectionPresenter.class_eval do
   # OVERRIDE Hyrax - removed size
-  delegate :collection_link, :date_created_d, :date_issued, :date_issued_d,
+  delegate :abstract, :collection_link, :date_created_d, :date_issued, :date_issued_d,
            :extent, :form, :publication_place, :repository, :rights_notes, :spatial,
            :utk_contributor, :utk_creator, :utk_publisher, to: :solr_document
 
   def self.terms
     %i[ total_items
+        abstract
         based_near
         collection_link
         creator contributor

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -1137,6 +1137,7 @@ en:
         form: 'Form'
         publication_place: 'Publication Place'
         repository: 'Repository'
+        rights_notes: 'Rights Notes'
         spatial: 'Spatial Coverage'
         utk_contributor: 'Local Contributor'
         utk_creator: 'Local Creator'

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -38,13 +38,14 @@ RSpec.describe Collection do
     it { is_expected.to have_property(:date_issued).with_predicate('http://purl.org/dc/terms/issued') }
     it { is_expected.to have_property(:date_issued_d).with_predicate('https://dbpedia.org/ontology/publicationDate') }
     it { is_expected.to have_property(:extent).with_predicate('http://rdaregistry.info/Elements/u/P60550') }
-    it { is_expected.to have_property(:form).with_predicate('http://www.europeana.eu/schemas/edm/hasType') }
+    it { is_expected.to have_property(:form).with_predicate('http://purl.org/dc/terms/format') }
     it { is_expected.to have_property(:keyword) }
     it { is_expected.to have_property(:license) }
     it { is_expected.to have_property(:publication_place).with_predicate('https://id.loc.gov/vocabulary/relators/pup') }
     it { is_expected.to have_property(:publisher) }
     it { is_expected.to have_property(:repository).with_predicate('http://id.loc.gov/vocabulary/relators/rps') }
     it { is_expected.to have_property(:resource_type) }
+    it { is_expected.to have_property(:rights_notes) }
     it { is_expected.to have_property(:rights_statement) }
     it { is_expected.to have_property(:spatial).with_predicate('http://purl.org/dc/terms/spatial') }
     it { is_expected.to have_property(:subject) }


### PR DESCRIPTION
# Summary 

I updated and added additional metadata per the client's [spreadsheet](https://docs.google.com/spreadsheets/d/1_0QVbQU_wj3ITUih5dGPGkWHN0QyhGO9hKSf6rXwKPc/edit#gid=365080784) and requested changes

ref #149 and the [original request ](https://github.com/scientist-softserv/utk-hyku/issues/126)

Updated the property uri of the form property
Added rights_notes
Added abstract to form and display
Removed license and rights statement from the form/show page
I am leaving Hyrax::BasicMetadata as this is default hyrax behavior/expectations

## Screenshot
<img width="1320" alt="Screen Shot 2022-10-31 at 11 29 36 AM" src="https://user-images.githubusercontent.com/10081604/199084543-355abaf8-5f90-44b7-9e75-4282ab3bb7df.png">

## Testing Instructions: 

The user should be able to create a collection w metadata manually and via bulkrax
[149-all-collection-metadata.csv](https://github.com/scientist-softserv/utk-hyku/files/9904470/149-all-collection-metadata.csv)

Sample file: 
