### PR TITLE
I127 fix CreateDerivativesJob bug

### DIFF
--- a/app/jobs/create_derivatives_job_decorator.rb
+++ b/app/jobs/create_derivatives_job_decorator.rb
@@ -9,7 +9,7 @@ module Hyrax
     # @param [String] file_id identifier for a Hydra::PCDM::File
     # @param [String, NilClass] filepath the cached file within the Hyrax.config.working_path
     # @param [Integer] time_to_live counter to limit the amount of retries
-    def perform(file_set, file_id, filepath = nil, _time_to_live = 2)
+    def perform(file_set, file_id, filepath = nil, time_to_live = 2)
       return if file_set.video? && !Hyrax.config.enable_ffmpeg
       # OVERRIDE HYRAX 3.4.1 to skip derivative job if rdf_type is "pcdm-muse:PreservationFile"
       if file_set.parent_works.blank?

--- a/app/jobs/create_derivatives_job_decorator.rb
+++ b/app/jobs/create_derivatives_job_decorator.rb
@@ -15,7 +15,7 @@ module Hyrax
       if file_set.parent_works.blank?
         raise 'CreateDerivatesJob Failed: FileSet is missing its parent' if time_to_live.zero?
 
-        reschedule(file_set, file_id, filepath)
+        reschedule(file_set, file_id, filepath, time_to_live - 1)
         return false
       end
 

--- a/app/jobs/create_derivatives_job_decorator.rb
+++ b/app/jobs/create_derivatives_job_decorator.rb
@@ -40,7 +40,7 @@ module Hyrax
 
       def reschedule(file_set, file_id, filepath = nil, time_to_live = 2)
         CreateDerivativesJob.set(wait: 10.minutes).perform_later(
-          file_set, file_id, filepath, time_to_live - 1
+          file_set, file_id, filepath, time_to_live
         )
       end
   end

--- a/app/jobs/create_derivatives_job_decorator.rb
+++ b/app/jobs/create_derivatives_job_decorator.rb
@@ -37,7 +37,7 @@ module Hyrax
 
     private
 
-      def reschedule(file_set, file_id, filepath = nil, time_to_live = 2)
+      def reschedule(file_set, file_id, filepath = nil, _time_to_live = 2)
         CreateDerivativesJob.set(wait: 10.minutes).perform_later(
           file_set, file_id, filepath, time_to_live - 1
         )

--- a/app/jobs/create_derivatives_job_decorator.rb
+++ b/app/jobs/create_derivatives_job_decorator.rb
@@ -12,7 +12,7 @@ module Hyrax
       return if file_set.video? && !Hyrax.config.enable_ffmpeg
       # OVERRIDE HYRAX 3.4.1 to skip derivative job if rdf_type is "pcdm-muse:PreservationFile"
       if file_set.parent_works.blank?
-        raise 'CreateDerivatesJob Failed: FileSet is missing its parent' if @remaining_retries.zero?
+        raise 'CreateDerivatesJob Failed: FileSet is missing its parent' if time_to_live.zero?
 
         reschedule(file_set, file_id, filepath)
         return false

--- a/app/jobs/create_derivatives_job_decorator.rb
+++ b/app/jobs/create_derivatives_job_decorator.rb
@@ -11,12 +11,8 @@ module Hyrax
     def perform(file_set, file_id, filepath = nil)
       return if file_set.video? && !Hyrax.config.enable_ffmpeg
       # OVERRIDE HYRAX 3.4.1 to skip derivative job if rdf_type is "pcdm-muse:PreservationFile"
-      @remaining_retries ||= 2
       if file_set.parent_works.blank?
-        raise 'FileSet is missing its parent' if @remaining_retries.zero?
-
         reschedule(file_set, file_id, filepath)
-        @remaining_retries -= 1
         return false
       end
 

--- a/app/jobs/create_derivatives_job_decorator.rb
+++ b/app/jobs/create_derivatives_job_decorator.rb
@@ -12,7 +12,7 @@ module Hyrax
       return if file_set.video? && !Hyrax.config.enable_ffmpeg
       # OVERRIDE HYRAX 3.4.1 to skip derivative job if rdf_type is "pcdm-muse:PreservationFile"
       if file_set.parent_works.blank?
-        raise 'CreateDerivateJob Failed: FileSet is missing its parent' if @remaining_retries.zero?
+        raise 'CreateDerivatesJob Failed: FileSet is missing its parent' if @remaining_retries.zero?
 
         reschedule(file_set, file_id, filepath)
         return false

--- a/app/jobs/create_derivatives_job_decorator.rb
+++ b/app/jobs/create_derivatives_job_decorator.rb
@@ -8,6 +8,7 @@ module Hyrax
     # @param [FileSet] file_set
     # @param [String] file_id identifier for a Hydra::PCDM::File
     # @param [String, NilClass] filepath the cached file within the Hyrax.config.working_path
+    # @param [String] time_to_live counter to limit the amount of retries
     def perform(file_set, file_id, filepath = nil, _time_to_live = 2)
       return if file_set.video? && !Hyrax.config.enable_ffmpeg
       # OVERRIDE HYRAX 3.4.1 to skip derivative job if rdf_type is "pcdm-muse:PreservationFile"

--- a/app/jobs/create_derivatives_job_decorator.rb
+++ b/app/jobs/create_derivatives_job_decorator.rb
@@ -38,7 +38,7 @@ module Hyrax
 
     private
 
-      def reschedule(file_set, file_id, filepath = nil, _time_to_live = 2)
+      def reschedule(file_set, file_id, filepath = nil, time_to_live = 2)
         CreateDerivativesJob.set(wait: 10.minutes).perform_later(
           file_set, file_id, filepath, time_to_live - 1
         )

--- a/app/jobs/create_derivatives_job_decorator.rb
+++ b/app/jobs/create_derivatives_job_decorator.rb
@@ -8,7 +8,7 @@ module Hyrax
     # @param [FileSet] file_set
     # @param [String] file_id identifier for a Hydra::PCDM::File
     # @param [String, NilClass] filepath the cached file within the Hyrax.config.working_path
-    # @param [String] time_to_live counter to limit the amount of retries
+    # @param [Integer] time_to_live counter to limit the amount of retries
     def perform(file_set, file_id, filepath = nil, _time_to_live = 2)
       return if file_set.video? && !Hyrax.config.enable_ffmpeg
       # OVERRIDE HYRAX 3.4.1 to skip derivative job if rdf_type is "pcdm-muse:PreservationFile"


### PR DESCRIPTION
@jeremyf noticed that the previous implementation wouldn't have worked because the counter instance variable would've been reset at each instantiation of the job. 

This MR updates the counter and is inspired by [this](https://gitlab.com/notch8/adventist-dl/-/blob/c924c8aed10d354d2c4992981b0905ef15a120f3/app/jobs/index_plain_text_files_job.rb) implementation. 