### PR TITLE
I162 bulkrax split delimeter

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,7 +18,7 @@ GIT
 
 GIT
   remote: https://github.com/samvera-labs/bulkrax
-  revision: 4f37e89d1cb0d3c2831069f5bdac1913a582d963
+  revision: d45a8846002af2c89dc722acc0c06401b0d16ba8
   specs:
     bulkrax (4.3.0)
       bagit (~> 0.4)
@@ -162,7 +162,7 @@ GEM
     babel-transpiler (0.7.0)
       babel-source (>= 4.0, < 6)
       execjs (~> 2.0)
-    bagit (0.4.4)
+    bagit (0.4.5)
       docopt (~> 0.5.0)
       validatable (~> 1.6)
     bcp47 (0.3.3)

--- a/config/initializers/bulkrax.rb
+++ b/config/initializers/bulkrax.rb
@@ -17,19 +17,6 @@ if ENV.fetch('HYKU_BULKRAX_ENABLED', 'true') == 'true'
       'bulkrax_identifier' => { from: ['source_identifier'], source_identifier: true },
       'children' => { from: ['children'], split: /\s*[;|]\s*/, related_children_field_mapping: true },
       'parents' => { from: ['parents'], split: /\s*[;|]\s*/, related_parents_field_mapping: true }
-      # # TODO: figure out why this is needed, it should be set automatically
-      # 'date_issued' => { from: ['date_issued'], split: /\s*[;|]\s*/ },
-      # 'extent' => { from: ['extent'], split: /\s*[;|]\s*/ },
-      # 'publication_place' => { from: ['publication_place'], split: /\s*[;|]\s*/ },
-      # 'repository' => { from: ['repository'], split: /\s*[;|]\s*/ },
-      # 'utk_contributor' => { from: ['utk_contributor'], split: /\s*[;|]\s*/ },
-      # 'utk_creator' => { from: ['utk_creator'], split: /\s*[;|]\s*/ },
-      # 'utk_publisher' => { from: ['utk_publisher'], split: /\s*[;|]\s*/ },
-      # 'form' => { from: ['form'], split: /\s*[;|]\s*/ },
-      # 'spatial' => { from: ['spatial'], split: /\s*[;|]\s*/ },
-      # # 'subject' => { from: ['subject'], split: /\s*[;|]\s*/ },
-      # 'date_created_d' => { from: ['date_created_d'], split: /\s*[;|]\s*/ },
-      # 'date_issued_d' => { from: ['date_issued_d'], split: /\s*[;|]\s*/ }
     }
 
     # OVERRIDE Bulkrax v4.3.0: change the default "split" behavior

--- a/config/initializers/bulkrax.rb
+++ b/config/initializers/bulkrax.rb
@@ -16,19 +16,20 @@ if ENV.fetch('HYKU_BULKRAX_ENABLED', 'true') == 'true'
     config.field_mappings['Bulkrax::CsvParser'] = {
       'bulkrax_identifier' => { from: ['source_identifier'], source_identifier: true },
       'children' => { from: ['children'], split: /\s*[;|]\s*/, related_children_field_mapping: true },
-      'parents' => { from: ['parents'], split: /\s*[;|]\s*/, related_parents_field_mapping: true },
-      # TODO: figure out why this is needed, it should be set automatically
-      'date_issued' => { from: ['date_issued'], split: /\s*[;|]\s*/ },
-      'extent' => { from: ['extent'], split: /\s*[;|]\s*/ },
-      'publication_place' => { from: ['publication_place'], split: /\s*[;|]\s*/ },
-      'repository' => { from: ['repository'], split: /\s*[;|]\s*/ },
-      'utk_contributor' => { from: ['utk_contributor'], split: /\s*[;|]\s*/ },
-      'utk_creator' => { from: ['utk_creator'], split: /\s*[;|]\s*/ },
-      'utk_publisher' => { from: ['utk_publisher'], split: /\s*[;|]\s*/ },
-      'form' => { from: ['form'], split: /\s*[;|]\s*/ },
-      'spatial' => { from: ['spatial'], split: /\s*[;|]\s*/ },
-      'date_created_d' => { from: ['date_created_d'], split: /\s*[;|]\s*/ },
-      'date_issued_d' => { from: ['date_issued_d'], split: /\s*[;|]\s*/ }
+      'parents' => { from: ['parents'], split: /\s*[;|]\s*/, related_parents_field_mapping: true }
+      # # TODO: figure out why this is needed, it should be set automatically
+      # 'date_issued' => { from: ['date_issued'], split: /\s*[;|]\s*/ },
+      # 'extent' => { from: ['extent'], split: /\s*[;|]\s*/ },
+      # 'publication_place' => { from: ['publication_place'], split: /\s*[;|]\s*/ },
+      # 'repository' => { from: ['repository'], split: /\s*[;|]\s*/ },
+      # 'utk_contributor' => { from: ['utk_contributor'], split: /\s*[;|]\s*/ },
+      # 'utk_creator' => { from: ['utk_creator'], split: /\s*[;|]\s*/ },
+      # 'utk_publisher' => { from: ['utk_publisher'], split: /\s*[;|]\s*/ },
+      # 'form' => { from: ['form'], split: /\s*[;|]\s*/ },
+      # 'spatial' => { from: ['spatial'], split: /\s*[;|]\s*/ },
+      # # 'subject' => { from: ['subject'], split: /\s*[;|]\s*/ },
+      # 'date_created_d' => { from: ['date_created_d'], split: /\s*[;|]\s*/ },
+      # 'date_issued_d' => { from: ['date_issued_d'], split: /\s*[;|]\s*/ }
     }
 
     # OVERRIDE Bulkrax v4.3.0: change the default "split" behavior


### PR DESCRIPTION
ref #162 and Bulkrax PR: https://github.com/samvera-labs/bulkrax/pull/664

A bug was found with the following scenario:

A client only had the necessary field mappings set (bulkrax_identifier, children, and parents). 

Because of this, [#mapping](https://github.com/samvera-labs/bulkrax/blob/main/app/models/bulkrax/importer.rb#L60-L72) would only return the field mapping. This caused an issue because [matcher](https://github.com/samvera-labs/bulkrax/blob/e88d0ea349afda5b3068836aa36ef86c93d4c62d/app/models/concerns/bulkrax/has_matchers.rb#L32) would return nil for all other imported values.

Because [it](https://github.com/samvera-labs/bulkrax/blob/e88d0ea349afda5b3068836aa36ef86c93d4c62d/app/models/concerns/bulkrax/has_matchers.rb#L44) was nil at the time of assigning the value, if the property was singular or multiple it would never process the split method to make [Subject A ; Subject B] into [Subject A, Subject B], for example.

This MR merges the default field mapping in with the field mapping, so that by default the splits would still be honored. It solves a bug found in bulkrax, but it also works for allinson flex's dynamic properties.

This was also tested using an importer with headers that didn't exist on any of the work types. Although it can be seen in the raw_metadata, parsed_metadata properly filters it out because #field_supported? returns false.

**NOTE**: in the following example donkey is an invalid field and should not be in the parsed metadata. And the client's default field mapping sets split to be a pipe. 


<img width="812" alt="Screen Shot 2022-11-02 at 12 31 11 PM" src="https://user-images.githubusercontent.com/10081604/199585635-02d4f00d-0aca-4227-aa68-bc22a999319f.png">
<img width="1006" alt="Screen Shot 2022-11-02 at 12 32 24 PM" src="https://user-images.githubusercontent.com/10081604/199585844-627ad6bd-e590-455f-830f-82b9a0dd1810.png">

## Testing Instructions
1. import sample files: 

Client data test:
[test.csv](https://github.com/scientist-softserv/utk-hyku/files/9931854/test.csv)

Collection only test:
[149-all-collection-metadata.csv](https://github.com/scientist-softserv/utk-hyku/files/9933291/149-all-collection-metadata.csv)

Invalid header test:
[donkey.csv](https://github.com/scientist-softserv/utk-hyku/files/9924679/donkey.csv)

3. Check the importer's parsed metadata section and/or the work's show page after the jobs finish
- [ ] any value that has the pipe delimiter should be treated as two separate values. 
- [ ] invalid properties (like donkey) should not be included in the parsed metadata and/or be displayed on the work's show page
- [ ] the invalid property will be present in the importer's raw metadata section