### PR TITLE
pick up deploy still being modified, fix db name inconsistancy

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -18,5 +18,5 @@ on:
 
 jobs:
   deploy:
-    uses: scientist-softserv/actions/.github/workflows/deploy.yaml@v0.0.1
+    uses: scientist-softserv/actions/.github/workflows/deploy.yaml@main
     secrets: inherit

--- a/ops/production-deploy.tmpl.yaml
+++ b/ops/production-deploy.tmpl.yaml
@@ -79,11 +79,9 @@ extraEnvVars: &envVars
   - name: DB_HOST
     value: postgres-cluster-alpha-ha.postgres.svc.cluster.local
   - name: DB_NAME
-    value: utk-hyku
+    value: utk-hyku-production-hyrax
   - name: DB_PASSWORD
     value: $DB_PASSWORD
-  - name: DB_URL
-    value: postgresql://postgres:$DB_PASSWORD@pg-postgresql.staging-postgres.svc.cluster.local
   - name: DB_USER
     value: main
   - name: FCREPO_BASE_PATH
@@ -206,6 +204,7 @@ externalPostgresql:
   host: postgres-cluster-alpha-ha.postgres.svc.cluster.local
   username: main
   password: $DB_PASSWORD
+  database: utk-hyku-production-hyrax
 
 externalSolrPassword: $SOLR_ADMIN_PASSWORD
 externalSolrHost: solr.solr.svc.cluster.local


### PR DESCRIPTION
- v0.0.1 of the actions deploy only deploys main because TAG is not set to DEPLOY_TAG. since we are working on self hosted runners, we're not ready for a new tag version yet. 
- DB_URL is created by the helm chart. its deceptive to show it in the values since that gets overridden by the chart.
- db name didn't match what as in the values.