### PR TITLE
remove Hyrax::BasicMetadata from Collection

### DIFF
--- a/app/forms/hyrax/forms/collection_form_decorator.rb
+++ b/app/forms/hyrax/forms/collection_form_decorator.rb
@@ -22,7 +22,6 @@ module Hyrax
           note
           publication_place
           publisher
-          related_url
           repository
           resource_type
           spatial
@@ -49,7 +48,8 @@ Hyrax::Forms::CollectionForm.terms += %i[
   repository
   spatial
   utk_contributor
-  utk_creator utk_publisher
+  utk_creator
+  utk_publisher
 ]
 
 Hyrax::Forms::CollectionForm.prepend(Hyrax::Forms::CollectionFormDecorator)

--- a/app/indexers/collection_indexer.rb
+++ b/app/indexers/collection_indexer.rb
@@ -3,7 +3,7 @@
 class CollectionIndexer < Hyrax::CollectionIndexer
   # This indexes the default metadata. You can remove it if you want to
   # provide your own metadata and indexing.
-  include Hyrax::IndexesBasicMetadata
+  # include Hyrax::IndexesBasicMetadata
 
   # Uncomment this block if you want to add custom indexing behavior:
   def generate_solr_document

--- a/app/indexers/collection_indexer.rb
+++ b/app/indexers/collection_indexer.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
 class CollectionIndexer < Hyrax::CollectionIndexer
-  # This indexes the default metadata. You can remove it if you want to
-  # provide your own metadata and indexing.
-  # include Hyrax::IndexesBasicMetadata
-
   # Uncomment this block if you want to add custom indexing behavior:
   def generate_solr_document
     super.tap do |solr_doc|

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -5,11 +5,28 @@ class Collection < ActiveFedora::Base
   include ::Hyrax::CollectionBehavior
   # You can replace these metadata if they're not suitable
 
+  property :abstract, predicate: ::RDF::Vocab::DC.abstract,
+                      multiple: false do |index|
+    index.as :displayable, :stored_searchable
+  end
+
   property :bulkrax_identifier,
            predicate: ::RDF::URI('https://hykucommons.org/terms/bulkrax_identifier'),
            multiple: false do |index|
     index.as :stored_searchable, :facetable
   end
+
+  property :contributor, predicate: ::RDF::URI('http://id.loc.gov/vocabulary/relators/ctb'),
+                         multiple: true do |index|
+    index.as :displayable, :stored_searchable
+  end
+
+  property :creator, predicate: ::RDF::URI('http://id.loc.gov/vocabulary/relators/cre'),
+                     multiple: true do |index|
+    index.as :displayable, :stored_searchable
+  end
+
+  property :date_created, predicate: ::RDF::Vocab::DC.created
 
   property :date_created_d,
            predicate: ::RDF::URI('https://dbpedia.org/ontology/completionDate'),
@@ -41,6 +58,11 @@ class Collection < ActiveFedora::Base
     index.as :displayable, :stored_searchable
   end
 
+  property :keyword, predicate: ::RDF::URI('https://w3id.org/idsa/core/keyword'),
+                     multiple: true do |index|
+    index.as :displayable, :stored_searchable
+  end
+
   property :note,
            predicate: ::RDF::URI('http://www.w3.org/2004/02/skos/core#note'),
            multiple: false do |index|
@@ -53,6 +75,11 @@ class Collection < ActiveFedora::Base
     index.as :displayable, :stored_searchable
   end
 
+  property :publisher, predicate: ::RDF::URI('http://id.loc.gov/vocabulary/relators/pbl'),
+                       multiple: false do |index|
+    index.as :displayable, :stored_searchable
+  end
+
   property :repository,
            predicate: ::RDF::URI('http://id.loc.gov/vocabulary/relators/rps'),
            multiple: true do |index|
@@ -62,6 +89,16 @@ class Collection < ActiveFedora::Base
   property :resource_link,
            predicate: ::RDF::URI('http://purl.org/dc/terms/identifier'),
            multiple: false do |index|
+    index.as :displayable, :stored_searchable
+  end
+
+  property :resource_type, predicate: ::RDF::Vocab::DC.type,
+                           multiple: true do |index|
+    index.as :displayable, :stored_searchable
+  end
+
+  property :subject, predicate: ::RDF::URI('http://purl.org/dc/terms/subject'),
+                     multiple: true do |index|
     index.as :displayable, :stored_searchable
   end
 
@@ -89,44 +126,7 @@ class Collection < ActiveFedora::Base
     index.as :displayable, :stored_searchable
   end
 
-  include Hyrax::BasicMetadata
-  # redefined Hyrax::BasicMetadata, but leaving the module
-  # as it's the default hyrax behavior and removing it may cause breaking changes
-  property :abstract, predicate: ::RDF::Vocab::DC.abstract,
-                      multiple: false do |index|
-    index.as :displayable, :stored_searchable
-  end
-
-  property :contributor, predicate: ::RDF::URI('http://id.loc.gov/vocabulary/relators/ctb'),
-                         multiple: true do |index|
-    index.as :displayable, :stored_searchable
-  end
-
-  property :creator, predicate: ::RDF::URI('http://id.loc.gov/vocabulary/relators/cre'),
-                     multiple: true do |index|
-    index.as :displayable, :stored_searchable
-  end
-
-  property :keyword, predicate: ::RDF::URI('https://w3id.org/idsa/core/keyword'),
-                     multiple: true do |index|
-    index.as :displayable, :stored_searchable
-  end
-
-  property :publisher, predicate: ::RDF::URI('http://id.loc.gov/vocabulary/relators/pbl'),
-                       multiple: false do |index|
-    index.as :displayable, :stored_searchable
-  end
-
-  property :resource_type, predicate: ::RDF::Vocab::DC.type,
-                           multiple: true do |index|
-    index.as :displayable, :stored_searchable
-  end
-
-  property :subject, predicate: ::RDF::URI('http://purl.org/dc/terms/subject'),
-                     multiple: true do |index|
-    index.as :displayable, :stored_searchable
-  end
-
+  # include Hyrax::CoreMetadata
   self.indexer = CollectionIndexer
   after_update :remove_featured, if: proc { |collection| collection.private? }
   after_destroy :remove_featured

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -126,7 +126,6 @@ class Collection < ActiveFedora::Base
     index.as :displayable, :stored_searchable
   end
 
-  # include Hyrax::CoreMetadata
   self.indexer = CollectionIndexer
   after_update :remove_featured, if: proc { |collection| collection.private? }
   after_destroy :remove_featured

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -32,10 +32,6 @@ class SolrDocument
   attribute :rendering_ids, Solr::Array, 'hasFormat_ssim'
   attribute :account_cname, Solr::Array, 'account_cname_tesim'
 
-  def resource_link
-    self['resource_link_tesim']
-  end
-
   def date_created_d
     self['date_created_d_tesim']
   end
@@ -64,6 +60,10 @@ class SolrDocument
     self['repository_tesim']
   end
 
+  def resource_link
+    self['resource_link_tesim']
+  end
+
   def spatial
     self['spatial_tesim']
   end
@@ -84,9 +84,6 @@ class SolrDocument
     contributor: 'contributor_tesim',
     creator: 'creator_tesim',
     date: 'date_created_tesim',
-    description: 'description_tesim',
-    identifier: 'identifier_tesim',
-    language: 'language_tesim',
     publisher: 'publisher_tesim',
     relation: 'nesting_collection__pathnames_ssim',
     rights: 'rights_statement_tesim',


### PR DESCRIPTION
This MR is a continuation of manually adding metadata to collection #102 

Rework was done due to a few misses + client changing metadata [specs](https://docs.google.com/spreadsheets/d/1_0QVbQU_wj3ITUih5dGPGkWHN0QyhGO9hKSf6rXwKPc/edit#gid=365080784)

Hopefully this will be the last update. It removes Hyrax::BasicMetadata references so that the collections will only have properties the client defined. 

Locally tested the following: 
- [ ] User is able to manually create collection w all metadata set
- [ ] User is able to import a collection w all metadata set. Resource link can be set via csv but not editable via the UI. 
- [ ] User is able to manually create an admin set. 
- [ ] User is able to upload a thumbnail to the collection.
- [ ] CRUD still works
