### PR TITLE
i149 collection metadata bug

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -96,7 +96,6 @@ class CatalogController < ApplicationController
     config.add_index_field 'lease_expiration_date_dtsi', label: "Lease expiration date", helper_method: :human_readable_date
 
     # collection metadata
-    config.add_index_field 'resource_link', label: 'Resource Link'
     config.add_index_field 'date_created_d_tesim', label: 'Machine Readable Creation Date'
     config.add_index_field 'date_issued_tesim', label: 'Date Issued'
     config.add_index_field 'date_issued_d_tesim', label: 'Machine Readable Publication Date'
@@ -104,6 +103,7 @@ class CatalogController < ApplicationController
     config.add_index_field 'form_tesim', label: 'Form'
     config.add_index_field 'publication_place_tesim', label: 'Publication Place'
     config.add_index_field 'repository_tesim', label: 'Repository'
+    config.add_index_field 'resource_link_tesim', label: 'Resource Link'
     config.add_index_field 'note_tesim', label: 'Note'
     config.add_index_field 'spatial_tesim', label: 'Spatial Coverage'
     config.add_index_field 'utk_contributor_tesim', label: 'Local Contributor'
@@ -132,13 +132,13 @@ class CatalogController < ApplicationController
     config.add_show_field 'extent_tesim'
 
     # add collection show fields
-    config.add_show_field 'resource_link', label: 'Resource Link'
     config.add_show_field 'date_created_d_tesim', label: 'Machine Readable Creation Date'
     config.add_show_field 'date_issued_tesim', label: 'Date Issued'
     config.add_show_field 'date_issued_d_tesim', label: 'Machine Readable Publication Date'
     config.add_show_field 'form_tesim', label: 'Form'
     config.add_show_field 'publication_place_tesim', label: 'Publication Place'
     config.add_show_field 'repository_tesim', label: 'Repository'
+    config.add_show_field 'resource_link_tesim', label: 'Resource Link'
     config.add_show_field 'note_tesim', label: 'Note'
     config.add_show_field 'spatial_tesim', label: 'Spatial Coverage'
     config.add_show_field 'utk_contributor_tesim', label: 'Local Contributor'

--- a/app/forms/hyrax/forms/collection_form_decorator.rb
+++ b/app/forms/hyrax/forms/collection_form_decorator.rb
@@ -22,7 +22,6 @@ module Hyrax
           note
           publication_place
           publisher
-          related_url
           repository
           resource_type
           spatial

--- a/app/forms/hyrax/forms/collection_form_decorator.rb
+++ b/app/forms/hyrax/forms/collection_form_decorator.rb
@@ -23,6 +23,7 @@ module Hyrax
           publication_place
           publisher
           repository
+          resource_link
           resource_type
           spatial
           subject
@@ -46,6 +47,7 @@ Hyrax::Forms::CollectionForm.terms += %i[
   note
   publication_place
   repository
+  resource_link
   spatial
   utk_contributor
   utk_creator utk_publisher

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -93,7 +93,7 @@ class Collection < ActiveFedora::Base
   # redefined Hyrax::BasicMetadata, but leaving the module
   # as it's the default hyrax behavior and removing it may cause breaking changes
   property :abstract, predicate: ::RDF::Vocab::DC.abstract,
-                      multiple: false do |index|
+                      multiple: true do |index|
     index.as :displayable, :stored_searchable
   end
 
@@ -113,7 +113,7 @@ class Collection < ActiveFedora::Base
   end
 
   property :publisher, predicate: ::RDF::URI('http://id.loc.gov/vocabulary/relators/pbl'),
-                       multiple: false do |index|
+                       multiple: true do |index|
     index.as :displayable, :stored_searchable
   end
 

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -60,7 +60,7 @@ class Collection < ActiveFedora::Base
   end
 
   property :resource_link,
-           predicate: ::RDF::URI('http://purl.org/dc/terms/identifier'),
+           predicate: ::RDF::Vocab::EDM.isShownAt,
            multiple: false do |index|
     index.as :displayable, :stored_searchable
   end
@@ -90,13 +90,8 @@ class Collection < ActiveFedora::Base
   end
 
   include Hyrax::BasicMetadata
-  # redefined Hyrax::BasicMetadata, but leaving the module
-  # as it's the default hyrax behavior and removing it may cause breaking changes
-  property :abstract, predicate: ::RDF::Vocab::DC.abstract,
-                      multiple: true do |index|
-    index.as :displayable, :stored_searchable
-  end
-
+  # The properties below redefine Hyrax::BasicMetadata to specify
+  # different property uris. Removing the module causes breaking changes
   property :contributor, predicate: ::RDF::URI('http://id.loc.gov/vocabulary/relators/ctb'),
                          multiple: true do |index|
     index.as :displayable, :stored_searchable
@@ -114,11 +109,6 @@ class Collection < ActiveFedora::Base
 
   property :publisher, predicate: ::RDF::URI('http://id.loc.gov/vocabulary/relators/pbl'),
                        multiple: true do |index|
-    index.as :displayable, :stored_searchable
-  end
-
-  property :resource_type, predicate: ::RDF::Vocab::DC.type,
-                           multiple: true do |index|
     index.as :displayable, :stored_searchable
   end
 

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -32,10 +32,6 @@ class SolrDocument
   attribute :rendering_ids, Solr::Array, 'hasFormat_ssim'
   attribute :account_cname, Solr::Array, 'account_cname_tesim'
 
-  def resource_link
-    self['resource_link_tesim']
-  end
-
   def date_created_d
     self['date_created_d_tesim']
   end
@@ -62,6 +58,10 @@ class SolrDocument
 
   def repository
     self['repository_tesim']
+  end
+
+  def resource_link
+    self['resource_link_tesim']
   end
 
   def spatial

--- a/app/presenters/hyrax/collection_presenter.rb
+++ b/app/presenters/hyrax/collection_presenter.rb
@@ -9,7 +9,7 @@ require_dependency Hyrax::Engine.root.join('app', 'presenters', 'hyrax', 'collec
 Hyrax::CollectionPresenter.class_eval do
   # OVERRIDE Hyrax - removed size
   delegate :abstract, :date_created_d, :date_issued, :date_issued_d,
-           :extent, :form, :resource_link, :publication_place, :repository,
+           :extent, :form, :publication_place, :repository, :resource_link,
            :note, :spatial, :utk_contributor, :utk_creator, :utk_publisher,
            to: :solr_document
 

--- a/app/views/records/edit_fields/_resource_link.html.erb
+++ b/app/views/records/edit_fields/_resource_link.html.erb
@@ -1,0 +1,5 @@
+<%= f.input :resource_link, 
+    readonly: true, 
+    label: 'Resource Link',
+    required: f.object.required?(key),
+    input_html: { class: 'form-control', multiple: false } %>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -1129,7 +1129,6 @@ en:
       collection:
         size: Size
         total_items: Total items
-        resource_link: Resource Link
         date_created_d: Machine Readable Creation Date
         date_issued: 'Date Issued'
         date_issued_d: 'Machine Readable Publication Date'
@@ -1138,6 +1137,7 @@ en:
         note: 'Note'
         publication_place: 'Publication Place'
         repository: 'Repository'
+        resource_link: Resource Link
         rights_notes: 'Rights Notes'
         spatial: 'Spatial Coverage'
         utk_contributor: 'Local Contributor'

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Collection do
     it { is_expected.to have_property(:publication_place).with_predicate('https://id.loc.gov/vocabulary/relators/pup') }
     it { is_expected.to have_property(:publisher).with_predicate('http://id.loc.gov/vocabulary/relators/pbl') }
     it { is_expected.to have_property(:repository).with_predicate('http://id.loc.gov/vocabulary/relators/rps') }
-    it { is_expected.to have_property(:resource_link).with_predicate('http://purl.org/dc/terms/identifier') }
+    it { is_expected.to have_property(:resource_link).with_predicate('http://www.europeana.eu/schemas/edm/isShownAt') }
     it { is_expected.to have_property(:resource_type).with_predicate('http://purl.org/dc/terms/type') }
     it { is_expected.to have_property(:spatial).with_predicate('http://purl.org/dc/terms/spatial') }
     it { is_expected.to have_property(:subject).with_predicate('http://purl.org/dc/terms/subject') }


### PR DESCRIPTION
Bug: A user imports a CSV to create a collection. When the user clicks Edit, the resource_link property doesn't persist. 

- [ ] This field should be read-only when editing/creating a collection. 
- [ ] This property can only be set via a bulkrax CSV import
- [ ] property uri has been updated per the client's changes

Sample File: [149-all-collection-metadata.csv](https://github.com/scientist-softserv/utk-hyku/files/9965988/149-all-collection-metadata.csv)

<img width="919" alt="Screen Shot 2022-11-08 at 10 11 29 AM" src="https://user-images.githubusercontent.com/10081604/200704141-16693721-b77e-43e7-b0e1-b92442838a43.png">
<img width="948" alt="Screen Shot 2022-11-08 at 10 12 14 AM" src="https://user-images.githubusercontent.com/10081604/200704143-b6427c96-91b1-4a5e-9ec3-a4a77916dd2e.png">
<img width="949" alt="Screen Shot 2022-11-08 at 4 12 29 PM" src="https://user-images.githubusercontent.com/10081604/200704323-7e068e7f-4a9a-47a9-8502-87b4ee10aa69.png">
<img width="975" alt="Screen Shot 2022-11-08 at 10 11 44 AM" src="https://user-images.githubusercontent.com/10081604/200704366-245b218e-dd42-4161-9a3d-2c0a6eec52d9.png">



