### PR TITLE
use 0.0.4 tag for actions library

### DIFF
--- a/.github/workflows/build-test-lint.yaml
+++ b/.github/workflows/build-test-lint.yaml
@@ -16,26 +16,27 @@ on:
 
 jobs:
   build:
-    uses: scientist-softserv/actions/.github/workflows/build.yaml@v0.0.1
+    uses: scientist-softserv/actions/.github/workflows/build.yaml@v0.0.4
+    secrets: inherit
     with:
       target: hyku-base
       worker: true
       workerTarget: hyku-worker
-      # tag: deca90d9
   test:
     needs: build
-    uses: scientist-softserv/actions/.github/workflows/test.yaml@v0.0.1
+    uses: scientist-softserv/actions/.github/workflows/test.yaml@v0.0.4
+    secrets: inherit
     with:
       worker: true
-      # tag: deca90d9
   lint:
     needs: build
-    uses: scientist-softserv/actions/.github/workflows/lint.yaml@v0.0.1
+    uses: scientist-softserv/actions/.github/workflows/lint.yaml@v0.0.4
+    secrets: inherit
     with:
       worker: true
-      # tag: deca90d9
   retag:
     needs: build
-    uses: scientist-softserv/actions/.github/workflows/retag.yaml@v0.0.1
+    uses: scientist-softserv/actions/.github/workflows/retag.yaml@v0.0.4
+    secrets: inherit
     with:
       worker: true

--- a/.github/workflows/build-test-lint.yaml
+++ b/.github/workflows/build-test-lint.yaml
@@ -25,12 +25,10 @@ jobs:
   test:
     needs: build
     uses: scientist-softserv/actions/.github/workflows/test.yaml@v0.0.5
-    secrets: inherit
     with:
       worker: true
   lint:
     needs: build
     uses: scientist-softserv/actions/.github/workflows/lint.yaml@v0.0.5
-    secrets: inherit
     with:
       worker: true

--- a/.github/workflows/build-test-lint.yaml
+++ b/.github/workflows/build-test-lint.yaml
@@ -34,9 +34,3 @@ jobs:
     secrets: inherit
     with:
       worker: true
-  retag:
-    needs: build
-    uses: scientist-softserv/actions/.github/workflows/retag.yaml@v0.0.4
-    secrets: inherit
-    with:
-      worker: true

--- a/.github/workflows/build-test-lint.yaml
+++ b/.github/workflows/build-test-lint.yaml
@@ -24,7 +24,7 @@ jobs:
       workerTarget: hyku-worker
   test:
     needs: build
-    uses: scientist-softserv/actions/.github/workflows/test.yaml@v0.0.4
+    uses: scientist-softserv/actions/.github/workflows/test.yaml@v0.0.3
     secrets: inherit
     with:
       worker: true

--- a/.github/workflows/build-test-lint.yaml
+++ b/.github/workflows/build-test-lint.yaml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   build:
-    uses: scientist-softserv/actions/.github/workflows/build.yaml@v0.0.4
+    uses: scientist-softserv/actions/.github/workflows/build.yaml@v0.0.5
     secrets: inherit
     with:
       target: hyku-base
@@ -24,13 +24,13 @@ jobs:
       workerTarget: hyku-worker
   test:
     needs: build
-    uses: scientist-softserv/actions/.github/workflows/test.yaml@v0.0.3
+    uses: scientist-softserv/actions/.github/workflows/test.yaml@v0.0.5
     secrets: inherit
     with:
       worker: true
   lint:
     needs: build
-    uses: scientist-softserv/actions/.github/workflows/lint.yaml@v0.0.4
+    uses: scientist-softserv/actions/.github/workflows/lint.yaml@v0.0.5
     secrets: inherit
     with:
       worker: true

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -18,5 +18,5 @@ on:
 
 jobs:
   deploy:
-    uses: scientist-softserv/actions/.github/workflows/deploy.yaml@v0.0.4
+    uses: scientist-softserv/actions/.github/workflows/deploy.yaml@v0.0.5
     secrets: inherit

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -18,5 +18,5 @@ on:
 
 jobs:
   deploy:
-    uses: scientist-softserv/actions/.github/workflows/deploy.yaml@main
+    uses: scientist-softserv/actions/.github/workflows/deploy.yaml@v0.0.4
     secrets: inherit


### PR DESCRIPTION
DO NOT MERGE UNTIL PIPELINE SUCCEEDS

This is updating the BUILD/TEST/LINT/DEPLOY actions to use the latest tag.