### PR TITLE
Use Hyrax 3.x-stable branch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -92,8 +92,8 @@ gem 'blacklight', '~> 6.7'
 gem 'blacklight_oai_provider', '~> 6.1', '>= 6.1.1'
 
 # gem 'hyrax', '~> 3.4.0'
-# lock to graph indexing update commit
-gem 'hyrax', git: 'https://github.com/samvera/hyrax.git', branch: 'additional-backport-graph-indexer-fixes'
+# pull in graph indexing work until a new version is released
+gem 'hyrax', git: 'https://github.com/samvera/hyrax.git', branch: '3.x-stable'
 # switch back to samvera/iiif_manifest main once https://github.com/samvera/iiif_manifest/pull/79 is approved
 gem 'iiif_manifest', git: 'https://github.com/notch8/iiif_manifest.git', branch: 'add-thumbnail-property'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,8 +47,8 @@ GIT
 
 GIT
   remote: https://github.com/samvera/hyrax.git
-  revision: 3492abbb62dc2b647729a51a83611a041799972a
-  branch: additional-backport-graph-indexer-fixes
+  revision: ce431a2c282345da2dca12c85f5afb3c16769fb1
+  branch: 3.x-stable
   specs:
     hyrax (3.4.2)
       active-fedora (~> 13.1, >= 13.1.2)


### PR DESCRIPTION
Hyrax graph indexer work was merged, so we are using the 3.x-stable branch until a new Hyrax version is minted.

Ref #188 
