### PR TITLE
[hot fix] set limits for utk servers

### DIFF
--- a/ops/production-deploy.tmpl.yaml
+++ b/ops/production-deploy.tmpl.yaml
@@ -1,5 +1,13 @@
 replicaCount: 2
 
+resources:
+  limits:
+    memory: "4Gi"
+    cpu: "2"
+  requests:
+    memory: "2Gi"
+    cpu: "1"
+
 livenessProbe:
   enabled: false
 readinessProbe:
@@ -161,6 +169,13 @@ extraEnvVars: &envVars
 
 worker:
   replicaCount: 1
+  resources:
+    limits:
+      memory: "4Gi"
+      cpu: "2"
+    requests:
+      memory: "2Gi"
+      cpu: "1"
   podSecurityContext:
     runAsUser: 1001
     runAsGroup: 101

--- a/ops/staging-deploy.tmpl.yaml
+++ b/ops/staging-deploy.tmpl.yaml
@@ -1,5 +1,13 @@
 replicaCount: 2
 
+resources:
+  requests:
+    memory: "1Gi"
+    cpu: "250m"
+  limits:
+    memory: "2Gi"
+    cpu: "1000m"
+
 livenessProbe:
   enabled: false
 readinessProbe:
@@ -171,6 +179,13 @@ extraEnvVars: &envVars
 
 worker:
   replicaCount: 1
+  resources:
+    requests:
+      memory: "1Gi"
+      cpu: "250m"
+    limits:
+      memory: "2Gi"
+      cpu: "1000m"
   podSecurityContext:
     runAsUser: 1001
     runAsGroup: 101


### PR DESCRIPTION
This should help fix production issues when a project uses too many resources. r2-besties shares its resources with many other projects. If one project uses too many resources, it can cause several projects' production instances to fail. By adding a limit we are setting a max amount of resources a project can consume. 