### PR TITLE
Override ContentEventJob

### DIFF
--- a/app/jobs/content_event_job_decorator.rb
+++ b/app/jobs/content_event_job_decorator.rb
@@ -1,12 +1,13 @@
 # frozen_string_literal: true
 
 # OVERRIDE Hyrax 3.x - Override log_user_event to avoid calling on nil user
-# Hyrax::Collections::CollectionMemberService.add_members_by_ids expects a user, 
-# which defaults to nil when called by the deprecated add_members method which is used in Bulkrax's CreateRelationships job.
+# Hyrax::Collections::CollectionMemberService.add_members_by_ids expects a user,
+# which defaults to nil when called by the deprecated add_members method
+# which is used in Bulkrax's CreateRelationships job.
 module ContentEventJobDecorator
   # log the event to the users profile stream
   def log_user_event(depositor)
-    depositor.log_profile_event(event) if depositor
+    depositor&.log_profile_event(event)
   end
 end
 

--- a/app/jobs/content_event_job_decorator.rb
+++ b/app/jobs/content_event_job_decorator.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# OVERRIDE Hyrax 3.x - Override log_user_event to avoid calling on nil user
+# Hyrax::Collections::CollectionMemberService.add_members_by_ids expects a user, 
+# which defaults to nil when called by the deprecated add_members method which is used in Bulkrax's CreateRelationships job.
+module ContentEventJobDecorator
+  # log the event to the users profile stream
+  def log_user_event(depositor)
+    depositor.log_profile_event(event) if depositor
+  end
+end
+
+ContentEventJob.prepend(ContentEventJobDecorator)


### PR DESCRIPTION
Do not call log_profile_event when depositor nil. 

Ref #138

> This comes from the Bulkrax::CreateRelationships job.
> 
> The [deprecation of the add_members method in collection_behavior routes to Hyrax::Collections::CollectionMemberService.add_members_by_ids, which expects a user, and passes nil by default](https://github.com/samvera/hyrax/blob/main/app/models/concerns/hyrax/collection_behavior.rb#L59-L61). This means that the [ObjectLifecycleListener receives an event with a nil user as it creates the ContentUpdateEventJob](https://github.com/samvera/hyrax/blob/main/app/services/hyrax/listeners/object_lifecycle_listener.rb#L29) and throws a NoMethodError on the log_profile_event call for each collection member that is added.
> 
> I have verified that this is only a notifier and not an indication of a failure. Collection relationships were created appropriately in spite of this notification error.
> 
> This could potentially be solved by changing to call the Hyrax::Collections::CollectionMemberService.add_members_by_ids directly in Bulkrax, but would limit which versions of Hyrax are supported. At this point, I am choosing to override hyrax to simply verify that we have a user before calling. Once Bulkrax uses the revised method, this override can be removed.

If I sleuthed correctly, this deprecation came in via Hyrax 3.1.0