### PR TITLE
update hyrax iiif av revision

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,7 +39,7 @@ GIT
 
 GIT
   remote: https://github.com/samvera-labs/hyrax-iiif_av.git
-  revision: b4577010a32ddc31239c47eb2d74e1fc579ade0e
+  revision: 76d448305e4e085bfb0e5b2856157000cd016cf4
   branch: utk-hyku-with-hyrax-3
   specs:
     hyrax-iiif_av (0.2.0)


### PR DESCRIPTION
ref: #217 

## Before:

Audio player would show links instead of the player bar

## After:

<img width="1181" alt="image" src="https://user-images.githubusercontent.com/19597776/205746527-53e612a1-8f19-4c37-a5bb-f92afe3bedc3.png">

This matches the behavior in ATLA
https://dl-staging.atla.com/concern/works/m900nt41q?locale=en

## Solution

When uploading a `.wav` the hyrax-iiif_av gem looks at the FileSet solr doc `#format` which returned `audio/x-wave` which did not render correctly in UV.  I instead hard coded `audio/mpeg` since the derivatives are `.mp3` format anyways.  This then fixed the issue.

https://github.com/samvera-labs/hyrax-iiif_av/commit/76d448305e4e085bfb0e5b2856157000cd016cf4

## NOTE
On ATLA, I tried uploading a `.wav` and it did not render a UV.
https://dl-staging.atla.com/concern/works/4j03cz75d?locale=en

The manifest does show it is `audio/x-wave` as well.
https://dl-staging.atla.com/concern/works/4j03cz75d/manifest.json