### PR TITLE
arm-wrestle

### DIFF
--- a/.github/workflows/build-test-lint.yaml
+++ b/.github/workflows/build-test-lint.yaml
@@ -35,7 +35,6 @@ jobs:
     secrets: inherit
     with:
       workerTarget: hyku-worker
-
   test:
     needs: build-web
     uses: scientist-softserv/actions/.github/workflows/test.yaml@v0.0.5

--- a/.github/workflows/build-test-lint.yaml
+++ b/.github/workflows/build-test-lint.yaml
@@ -36,12 +36,12 @@ jobs:
     with:
       target: hyku-worker
   test:
-    needs: build-web && build-worker
+    needs: build-web, build-worker
     uses: scientist-softserv/actions/.github/workflows/test.yaml@v0.0.5
     with:
       worker: true
   lint:
-    needs: build-web && build-worker
+    needs: build-web, build-worker
     uses: scientist-softserv/actions/.github/workflows/lint.yaml@v0.0.5
     with:
       worker: true

--- a/.github/workflows/build-test-lint.yaml
+++ b/.github/workflows/build-test-lint.yaml
@@ -36,12 +36,12 @@ jobs:
     with:
       target: hyku-worker
   test:
-    needs: build-web
+    needs: build-web && build-worker
     uses: scientist-softserv/actions/.github/workflows/test.yaml@v0.0.5
     with:
       worker: true
   lint:
-    needs: build-web
+    needs: build-web && build-worker
     uses: scientist-softserv/actions/.github/workflows/lint.yaml@v0.0.5
     with:
       worker: true

--- a/.github/workflows/build-test-lint.yaml
+++ b/.github/workflows/build-test-lint.yaml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   build:
-    uses: scientist-softserv/actions/.github/workflows/build.yaml@v005-but-on-github-runners
+    uses: scientist-softserv/actions/.github/workflows/build.yaml@arm-wrestle
     secrets: inherit
     with:
       target: hyku-base
@@ -24,11 +24,11 @@ jobs:
       workerTarget: hyku-worker
   test:
     needs: build
-    uses: scientist-softserv/actions/.github/workflows/test.yaml@v005-but-on-github-runners
+    uses: scientist-softserv/actions/.github/workflows/test.yaml@v0.0.5
     with:
       worker: true
   lint:
     needs: build
-    uses: scientist-softserv/actions/.github/workflows/lint.yaml@v005-but-on-github-runners
+    uses: scientist-softserv/actions/.github/workflows/lint.yaml@v0.0.5
     with:
       worker: true

--- a/.github/workflows/build-test-lint.yaml
+++ b/.github/workflows/build-test-lint.yaml
@@ -15,20 +15,34 @@ on:
         default: false
 
 jobs:
-  build:
-    uses: scientist-softserv/actions/.github/workflows/build.yaml@arm-wrestle
+  build-web:
+    uses: scientist-softserv/actions/.github/workflows/build-web.yaml@arm-wrestle
     secrets: inherit
     with:
       target: hyku-base
-      worker: true
+  build-web-arm64:
+    uses: scientist-softserv/actions/.github/workflows/build-web-arm64.yaml@arm-wrestle
+    secrets: inherit
+    with:
+      target: hyku-base
+  build-worker:
+    uses: scientist-softserv/actions/.github/workflows/build-worker.yaml@arm-wrestle
+    secrets: inherit
+    with:
       workerTarget: hyku-worker
+  build-worker-arm64:
+    uses: scientist-softserv/actions/.github/workflows/build-worker-arm64.yaml@arm-wrestle
+    secrets: inherit
+    with:
+      workerTarget: hyku-worker
+
   test:
-    needs: build
+    needs: build-web
     uses: scientist-softserv/actions/.github/workflows/test.yaml@v0.0.5
     with:
       worker: true
   lint:
-    needs: build
+    needs: build-web
     uses: scientist-softserv/actions/.github/workflows/lint.yaml@v0.0.5
     with:
       worker: true

--- a/.github/workflows/build-test-lint.yaml
+++ b/.github/workflows/build-test-lint.yaml
@@ -29,12 +29,12 @@ jobs:
     uses: scientist-softserv/actions/.github/workflows/build-worker.yaml@arm-wrestle
     secrets: inherit
     with:
-      workerTarget: hyku-worker
+      target: hyku-worker
   build-worker-arm64:
     uses: scientist-softserv/actions/.github/workflows/build-worker-arm64.yaml@arm-wrestle
     secrets: inherit
     with:
-      workerTarget: hyku-worker
+      target: hyku-worker
   test:
     needs: build-web
     uses: scientist-softserv/actions/.github/workflows/test.yaml@v0.0.5

--- a/.github/workflows/build-test-lint.yaml
+++ b/.github/workflows/build-test-lint.yaml
@@ -36,12 +36,12 @@ jobs:
     with:
       target: hyku-worker
   test:
-    needs: build-web, build-worker
+    needs: build-web
     uses: scientist-softserv/actions/.github/workflows/test.yaml@v0.0.5
     with:
       worker: true
   lint:
-    needs: build-web, build-worker
+    needs: build-web
     uses: scientist-softserv/actions/.github/workflows/lint.yaml@v0.0.5
     with:
       worker: true


### PR DESCRIPTION
Ref ticket: https://github.com/scientist-softserv/dev-ops/issues/498

Updates to use the arm-wrestle branch for actions:
- separates the web/worker/solr builds
- and separates the platform builds arm64/amd64
- which allows our tests, lint, and deploys to happen before the arm64 image is even built and pushed to the registry since the lint/tests only depend on the amd64 build (which is roughly 15 minutes), and the deploy depends on the sha that is pushed to the registry form the amd64 build and push.

https://github.com/scientist-softserv/actions/pull/18