### PR TITLE
update revision for hyrax iiif av gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,7 +20,7 @@ GIT
 
 GIT
   remote: https://github.com/samvera-labs/hyrax-iiif_av.git
-  revision: 76d448305e4e085bfb0e5b2856157000cd016cf4
+  revision: cee8efd2f74ae61ba567db5bee033c96b172c162
   branch: utk-hyku-with-hyrax-3
   specs:
     hyrax-iiif_av (0.2.0)


### PR DESCRIPTION
ref #217 

- added another edge case for duration where audio files characterized with milliseconds in the duration would cause the manifest to blow up; https://github.com/samvera-labs/hyrax-iiif_av/commit/88f506d31021fa9006e00ee5aa7d3dd2bbb230fc
- added `auth_service` back into the manifest for audio files; https://github.com/samvera-labs/hyrax-iiif_av/commit/cee8efd2f74ae61ba567db5bee033c96b172c162

