### PR TITLE
make-test-lint-depend-on-worker-too

### DIFF
--- a/.github/workflows/build-test-lint.yaml
+++ b/.github/workflows/build-test-lint.yaml
@@ -36,12 +36,12 @@ jobs:
     with:
       target: hyku-worker
   test:
-    needs: build-web
+    needs: [build-web, build-worker]
     uses: scientist-softserv/actions/.github/workflows/test.yaml@make-pipeline-fail-if-tests-fail
     with:
       worker: true
   lint:
-    needs: build-web
+    needs: [build-web, build-worker]
     uses: scientist-softserv/actions/.github/workflows/lint.yaml@v0.0.5
     with:
       worker: true


### PR DESCRIPTION
Tests and lint would intermittently fail on this branch of the actions because they were only dependent on the web pod, this updates it to be dependent on the worker so it wait for both to be complete before starting the tests or linting jobs since they need the worker too.