### PR TITLE
Browse Collections - All Collections Grid View Update

### DIFF
--- a/app/assets/stylesheets/themes/dc_repository.scss
+++ b/app/assets/stylesheets/themes/dc_repository.scss
@@ -471,6 +471,7 @@ body.dc_repository {
         padding-left: $golden-ratio-3;
         margin-right: auto;
         margin-left: auto;
+        margin-bottom: $golden-ratio-4;
 
         .home-content {
           .nav {
@@ -497,12 +498,12 @@ body.dc_repository {
 
     .collections-row {
       padding-top: 40px;
-      padding-bottom: 40px;
     }
 
     .collection-card-container {
       flex-direction: column;
       height: 500px;
+      margin-bottom: $golden-ratio-4;
 
       .collection-card {
         background-color: $white;
@@ -516,6 +517,9 @@ body.dc_repository {
 
     .collection-label {
       padding: 15px !important;
+      align-self: center;
+      line-height: 1.29em;
+      letter-spacing: -0.029em;
 
       a,
       a:visited {
@@ -535,9 +539,7 @@ body.dc_repository {
       object-position: center;
       &[src*="default_collection_images"],
       &[src^="/assets/collection"] {
-        width: 130px;
-        height: 130px;
-        margin: 35px auto;
+        object-fit: contain;
       }
     }
   }
@@ -1161,6 +1163,10 @@ body.dc_repository {
         }
       }
 
+      .collection-card-container {
+        margin-bottom: $golden-ratio-3;
+      }
+
       .collection-label {
         padding: 15px !important;
 
@@ -1171,7 +1177,6 @@ body.dc_repository {
 
       .collections-row {
         padding-top: $golden-ratio-3;
-        padding-bottom: $golden-ratio-3;
       }
 
       .home-content > div {
@@ -1208,7 +1213,6 @@ body.dc_repository {
       }
     }
 
-    // Featured collections section
     // Featured Collections & Browse Collections Grid
     #featured-collections,
     #browse-collections {
@@ -1222,6 +1226,7 @@ body.dc_repository {
 
         .collection-card-container {
           height: 400px;
+          margin-bottom: $golden-ratio-2;
 
           .collection-card {
             margin-bottom: 0;
@@ -1230,6 +1235,10 @@ body.dc_repository {
           .collection-thumbnail img {
             height: 300px;
             width: 80%;
+          }
+
+          .collection-label {
+            max-width: 70%;
           }
         }
 
@@ -1376,18 +1385,30 @@ body.dc_repository {
         padding: 0 $golden-ratio-2 !important;
       }
     }
-  }
 
-  @media (min-width: 575px) {
-    // Featured collections section
-    #featured-collections {
-      .featured-collections {
+    // Featured Collections & Browse Collections Grid
+    #featured-collections,
+    #browse-collections {
+      .featured-collections,
+      .browse-collections {
         .container {
           max-width: 100%;
         }
+
+        .collection-label {
+          padding-top: 15px !important;
+          margin-left: auto;
+          margin-right: auto;
+        }
+
+        .collection-card-container {
+          margin-bottom: $golden-ratio-2;
+        }
       }
     }
+  }
 
+  @media (min-width: 575px) {
     // Footers
     #utk-lib-footer {
       .footer-libraries,

--- a/app/views/themes/dc_repository/hyrax/homepage/_browse_collections.html.erb
+++ b/app/views/themes/dc_repository/hyrax/homepage/_browse_collections.html.erb
@@ -8,7 +8,7 @@
       <div class="collection-thumbnail center-block">
         <%= render_thumbnail_tag(collection, { class: "center-block", alt: "#{collection.title.first} #{ t('hyrax.homepage.admin_sets.thumbnail')}" }, {suppress_link: true}) %>
       </div>
-      <div class= "collection-label">
+      <div class= "collection-label d-flex">
         <%= link_to [hyrax, collection] do %>
           <%= collection.title.first %>
         <% end %>


### PR DESCRIPTION
## Summary
Custom theming for Browse Collections section grid view only
- add flexbox to div
- update styles for default thumbnail and long collection titles

## Related Ticket
[Browse Collections - All Collections Grid View#61](https://github.com/scientist-softserv/utk-hyku/issues/61)

## Screencasts
### Full Screen

https://user-images.githubusercontent.com/39319859/207474697-5fde767c-0b4e-4527-806e-3207fe1131ca.mp4

### Medium Screen

https://user-images.githubusercontent.com/39319859/207474732-7731ee42-444d-4798-ad53-7e8d04df7643.mp4

### Small Screen

https://user-images.githubusercontent.com/39319859/207474747-5598de3d-fcc3-4d02-9156-15bb8bfdfd8b.mp4

### X-Small Screen

https://user-images.githubusercontent.com/39319859/207474783-c5eee268-ab07-4ba0-83f1-af9dd4c422f7.mp4



## QA Instructions
- [ ] These changes should render the default thumbnail correctly.