### PR TITLE
[i149] - fix for resource_type was not saving when importing with bulkrax

### DIFF
--- a/app/matchers/bulkrax/application_mathcer_decorator.rb
+++ b/app/matchers/bulkrax/application_mathcer_decorator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # fronen_string_literatl: true
 
 # OVERRIDE BULKRAX 4.4.0 to remove resource_type from #process_parse
@@ -11,12 +13,12 @@ module Bulkrax
       parsed_fields = ['remote_files', 'language', 'subject', 'types', 'model', 'format_original']
       # This accounts for prefixed matchers
       parser = parsed_fields.find { |field| to&.include? field }
-      if @result.is_a?(Array) && self.parsed && self.respond_to?("parse_#{parser}")
+      if @result.is_a?(Array) && parsed && respond_to?("parse_#{parser}")
         @result.each_with_index do |res, index|
           @result[index] = send("parse_#{parser}", res.strip)
         end
         @result.delete(nil)
-      elsif self.parsed && self.respond_to?("parse_#{parser}")
+      elsif parsed && respond_to?("parse_#{parser}")
         @result = send("parse_#{parser}", @result)
       end
     end

--- a/app/matchers/bulkrax/application_mathcer_decorator.rb
+++ b/app/matchers/bulkrax/application_mathcer_decorator.rb
@@ -1,0 +1,26 @@
+# fronen_string_literatl: true
+
+# OVERRIDE BULKRAX 4.4.0 to remove resource_type from #process_parse
+# this app redefined resouce_types.yml to be inline with local questioning
+# authority
+module Bulkrax
+  module ApplicationMatcherDecorator
+    def process_parse
+      # New parse methods will need to be added here
+      # OVERRIDE BULKRAX 4.4.0 to remove resource_type from #process_parse
+      parsed_fields = ['remote_files', 'language', 'subject', 'types', 'model', 'format_original']
+      # This accounts for prefixed matchers
+      parser = parsed_fields.find { |field| to&.include? field }
+      if @result.is_a?(Array) && self.parsed && self.respond_to?("parse_#{parser}")
+        @result.each_with_index do |res, index|
+          @result[index] = send("parse_#{parser}", res.strip)
+        end
+        @result.delete(nil)
+      elsif self.parsed && self.respond_to?("parse_#{parser}")
+        @result = send("parse_#{parser}", @result)
+      end
+    end
+  end
+end
+
+Bulkrax::ApplicationMatcher.prepend(Bulkrax::ApplicationMatcherDecorator)

--- a/app/matchers/bulkrax/application_mathcer_decorator.rb
+++ b/app/matchers/bulkrax/application_mathcer_decorator.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-# fronen_string_literatl: true
-
 # OVERRIDE BULKRAX 4.4.0 to remove resource_type from #process_parse
 # this app redefined resouce_types.yml to be inline with local questioning
 # authority

--- a/config/authorities/resource_types.yml
+++ b/config/authorities/resource_types.yml
@@ -1,41 +1,28 @@
 terms:
-  - id: Article
-    term: Article
-  - id: Audio
+  - id: http://id.loc.gov/vocabulary/resourceTypes/txt
+    term: Text
+    active: true
+  - id: http://id.loc.gov/vocabulary/resourceTypes/car
+    term: Cartographic
+    active: true
+  - id: http://id.loc.gov/vocabulary/resourceTypes/not
+    term: Notated music
+    active: true
+  - id: http://id.loc.gov/vocabulary/resourceTypes/aun
+    term: Audio non-musical
+    active: true
+  - id: http://id.loc.gov/vocabulary/resourceTypes/aud
     term: Audio
-  - id: Book
-    term: Book
-  - id: Capstone Project
-    term: Capstone Project
-  - id: Conference Proceeding
-    term: Conference Proceeding
-  - id: Dataset
-    term: Dataset
-  - id: Dissertation
-    term: Dissertation
-  - id: Image
-    term: Image
-  - id: Journal
-    term: Journal
-  - id: Map or Cartographic Material
-    term: Map or Cartographic Material
-  - id: Masters Thesis
-    term: Masters Thesis
-  - id: Part of Book
-    term: Part of Book
-  - id: Poster
-    term: Poster
-  - id: Presentation
-    term: Presentation
-  - id: Project
-    term: Project
-  - id: Report
-    term: Report
-  - id: Research Paper
-    term: Research Paper
-  - id: Software or Program Code
-    term: Software or Program Code
-  - id: Video
-    term: Video
-  - id: Other
-    term: Other
+    active: true
+  - id: http://id.loc.gov/vocabulary/resourceTypes/img
+    term: Still image
+    active: true
+  - id: http://id.loc.gov/vocabulary/resourceTypes/mov
+    term: Moving image
+    active: true
+  - id: http://id.loc.gov/vocabulary/resourceTypes/art
+    term: Artifact
+    active: true
+  - id: http://id.loc.gov/vocabulary/resourceTypes/col
+    term: Collection
+    active: true

--- a/config/initializers/bulkrax.rb
+++ b/config/initializers/bulkrax.rb
@@ -85,6 +85,8 @@ if ENV.fetch('HYKU_BULKRAX_ENABLED', 'true') == 'true'
 
     # Properties that should not be used in imports/exports. They are reserved for use by Hyrax.
     # config.reserved_properties += ['my_field']
+
+    config.qa_controlled_properties += ['resource_types']
   end
 end
 


### PR DESCRIPTION
# Summary

While addressing @mlhale7 concerns, we noticed that resource type value was not getting saved when imported through bulkrax. 

## Acceptance Criteria

- [ ] a user should be able to import a resource_type via bulkrax, and have it persist on the imported object.

## Screenshots

**IMAGE**
![image](https://user-images.githubusercontent.com/10081604/207726297-d57e4440-cda4-4a6c-92e0-f769498879dc.png)
![image](https://user-images.githubusercontent.com/10081604/207733210-a49ae134-3ff4-48f3-9816-9c04d096e5d6.png)
![image](https://user-images.githubusercontent.com/10081604/207733280-75bd09fd-4bf9-4761-b05d-401252ac76ae.png)
![image](https://user-images.githubusercontent.com/10081604/207733395-9fbcf0af-ce9f-4f14-8385-3ed591d06c09.png)


**COLLECTION**
![image](https://user-images.githubusercontent.com/10081604/207726425-e229941c-9816-45c6-ad18-1160f72d82ad.png)
![image](https://user-images.githubusercontent.com/10081604/207726492-b0d55ba9-cfce-4364-9210-cd56c644029f.png)
![image](https://user-images.githubusercontent.com/10081604/207726624-a6ceabda-0369-4d65-ab9a-cd5b655e03e5.png)
![image](https://user-images.githubusercontent.com/10081604/207730779-643ec2b0-e10e-4f75-851a-d5a421ad4a5e.png)

## Testing Instructions
Import a CSV with resource_type values. They should be set to one of the uris available in the config/authorities/resource_types.yml file 

Sample File: [heilman_full_with_collections_short.csv](https://github.com/scientist-softserv/utk-hyku/files/10232022/heilman_full_with_collections_short.csv)


- [ ] Verify that the Image has a value for resource_type (uri)
- [ ] Verify that the imported Collection has a value for resource_type (uri)