### PR TITLE
Browse Collections - Finalize Section

### DIFF
--- a/app/assets/stylesheets/themes/dc_repository.scss
+++ b/app/assets/stylesheets/themes/dc_repository.scss
@@ -619,7 +619,7 @@ body.dc_repository {
               a {
                 margin: 0;
                 border: none;
-                border-radius: 0;
+                border-radius: $golden-ratio-4;
                 padding: 0;
               }
             }

--- a/app/assets/stylesheets/themes/dc_repository.scss
+++ b/app/assets/stylesheets/themes/dc_repository.scss
@@ -606,6 +606,12 @@ body.dc_repository {
           margin-left: 0;
         }
 
+        button:first-child:active,
+        button:first-child:focus {
+          background-color: $white;
+          color: $globe;
+        }
+
         .browse-collections--view {
           .nav {
             margin: 0;
@@ -646,8 +652,8 @@ body.dc_repository {
             border-top-right-radius: 0;
             border-bottom-right-radius: 0;
             border: none;
-            background-color: #00597a !important;
-            color: $white !important;
+            background-color: #00597a;
+            color: $white;
             box-shadow: 0 2px 5px rgba(51, 51, 51, 0.15) !important;
             cursor: default !important;
             font-weight: 400;

--- a/app/assets/stylesheets/themes/dc_repository.scss
+++ b/app/assets/stylesheets/themes/dc_repository.scss
@@ -581,7 +581,7 @@ body.dc_repository {
           border-radius: $golden-ratio-4;
           border: 1px solid $gray-2;
           font-size: $type-1;
-          margin-left: $golden-ratio-2;
+          margin-left: 0;
           cursor: pointer;
           outline: none;
           font-weight: 700;
@@ -600,10 +600,6 @@ body.dc_repository {
           margin-right: $golden-ratio-0;
           opacity: 0.47;
           display: block;
-        }
-
-        button:first-child {
-          margin-left: 0;
         }
 
         button:first-child:active,
@@ -648,36 +644,31 @@ body.dc_repository {
         }
 
         .browse-collections--toggles {
-          .button-toggle:last-of-type {
-            border-top-right-radius: 0;
-            border-bottom-right-radius: 0;
-            border: none;
-            background-color: #00597a;
-            color: $white;
-            box-shadow: 0 2px 5px rgba(51, 51, 51, 0.15) !important;
-            cursor: default !important;
-            font-weight: 400;
+          // Styles for hidden 'Group' button in case it's used in the future
+          // .button-toggle:last-of-type {
+          //   border-top-right-radius: 0;
+          //   border-bottom-right-radius: 0;
+          //   border: none;
+          //   background-color: #00597a;
+          //   color: $white;
+          //   box-shadow: 0 2px 5px rgba(51, 51, 51, 0.15) !important;
+          //   cursor: default !important;
+          //   font-weight: 400;
+          // }
+
+          .browse-collections--search {
+            background-color: $globe;
+
+            a {
+              color: $white;
+            }
           }
 
-          .ui.dropdown {
-            position: relative;
-            z-index: 1000;
-            width: auto;
-            font-size: $type-1;
+          .browse-collections--search:hover {
+            background-color: $white;
 
-            .text {
-              cursor: pointer;
-              height: $golden-ratio-4;
-              padding: 0 $golden-ratio-2;
-              border-radius: $golden-ratio-4;
-              border-top-left-radius: 0;
-              border-bottom-left-radius: 0;
-              line-height: $golden-ratio-4;
-              align-items: center;
-              background-color: $globe;
-              color: $white;
-              opacity: 1;
-              font-weight: 700;
+            a {
+              color: $smokey;
             }
           }
         }

--- a/app/controllers/hyrax/homepage_controller.rb
+++ b/app/controllers/hyrax/homepage_controller.rb
@@ -46,7 +46,7 @@ module Hyrax
       @announcement_text = ContentBlock.for(:announcement)
       recent
       ir_counts if home_page_theme == 'institutional_repository'
-      @collections_list = collections(rows: 100_000) if home_page_theme == 'dc_repository'
+      @collections_list = collections(rows: 50) if home_page_theme == 'dc_repository'
 
       # override hyrax v2.9.0 added for facets on homepage - Adding Themes
       (@response, @document_list) = search_results(params)

--- a/app/views/themes/dc_repository/hyrax/homepage/_browse_collections_section.html.erb
+++ b/app/views/themes/dc_repository/hyrax/homepage/_browse_collections_section.html.erb
@@ -22,12 +22,13 @@
             </li>
           </div>
           <div class="browse-collections--toggles d-flex">
-            <button class="button-toggle d-flex"><i class="fa fa-caret-up" aria-hidden="true"></i>A-Z</button>
-            <button class="button-toggle d-flex">Group</button>
-            <div name="group" role="listbox" aria-expanded="false" class="ui dropdown d-flex" tabindex="0">
-              <div class="text" role="alert" aria-live="polite" aria-atomic="true">
-                All Collections
-              </div>
+            <%# These two buttons are hidden due to design change but are left in if they are to be used in the future %>
+            <button class="button-toggle hidden d-flex"><i class="fa fa-caret-up" aria-hidden="true"></i>A-Z</button>
+            <button class="button-toggle hidden d-flex">Group</button>
+            <div class="d-flex">
+              <button class="browse-collections--search" role="alert" aria-live="polite" aria-atomic="true">
+                <%= link_to t('hyrax.homepage.admin_sets.link'), main_app.search_catalog_path(f: { human_readable_type_sim: ["Collection"]}) %>
+              </button>
             </div>
           </div>
         </ul>


### PR DESCRIPTION
### Summary
- update styles to remove hover effect on grid/list buttons
- limit all collection items on homepage to max 50
- hide A-Z and Group buttons
- convert View all collections from dropdown to button
- update styles for view all collections button

### Related Ticket
[#260 - Browse Collections - Finalize Section](https://github.com/scientist-softserv/utk-hyku/issues/260)

### Screenshots
![Screenshot 2022-12-20 at 9 59 19 AM](https://user-images.githubusercontent.com/39319859/208734852-4f2da56a-61ce-4e93-a6e7-c44a08fd123c.JPG)

Hover state
![Screenshot 2022-12-20 at 9 59 29 AM](https://user-images.githubusercontent.com/39319859/208735025-fdde4885-f2bf-4b4d-89de-4178e8b23ab9.JPG)

Links to Search filtered to All Collections
![Screenshot 2022-12-20 at 9 59 49 AM](https://user-images.githubusercontent.com/39319859/208735147-0e4c410a-8b44-4f95-afd4-e222bc8b3d51.JPG)


### QA Instructions
- These changes only apply to the DC Repository theme - all other themes should have default styling
- Test on staging at https://dc.utk-hyku-staging.notch8.cloud/
- Test on browsers
- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- Looks like screenshots above
- [ ] Large screen 992px and above
- [ ] Hover state of View all collections button
- [ ] Links to Search results page filtered to collections
