### PR TITLE
[i290] scale worker replica count to 3

### DIFF
--- a/ops/production-deploy.tmpl.yaml
+++ b/ops/production-deploy.tmpl.yaml
@@ -170,7 +170,7 @@ extraEnvVars: &envVars
     value: production
 
 worker:
-  replicaCount: 1
+  replicaCount: 3
   resources:
     limits:
       memory: "4Gi"


### PR DESCRIPTION
This should default the production's worker scale to 3. 

ref: #290 

