### PR TITLE
update bulkrax to errored tab branch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -85,7 +85,8 @@ group :development do
   # gem 'xray-rails' # when using this gem, know that sidekiq will not work
 end
 
-gem 'bulkrax', git: 'https://github.com/samvera-labs/bulkrax.git', branch: 'main'
+# until errored entries are fully fixed and implemented, pointing to this wip branch
+gem 'bulkrax', git: 'https://github.com/samvera-labs/bulkrax.git', branch: 'errored-entries-tab'
 
 gem 'allinson_flex', git: 'https://github.com/samvera-labs/allinson_flex.git'
 gem 'blacklight', '~> 6.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,8 +10,8 @@ GIT
 
 GIT
   remote: https://github.com/samvera-labs/bulkrax.git
-  revision: 68c52a6b97ee6242e866ef4eb8d346516aa93bc3
-  branch: main
+  revision: 025461570d6ae129778076345c3ab0a3a1cd095c
+  branch: errored-entries-tab
   specs:
     bulkrax (4.4.0)
       bagit (~> 0.4)


### PR DESCRIPTION
ref #291 

- implement an easier way to retrieve errored entries
<img width="1615" alt="image" src="https://user-images.githubusercontent.com/19597776/211058153-fc441b9b-4402-448c-9ac1-72036ef683ca.png">
