### PR TITLE
i64 Search Results Page Update

### DIFF
--- a/app/views/catalog/_index_default.html.erb
+++ b/app/views/catalog/_index_default.html.erb
@@ -2,16 +2,15 @@
 
 <% doc_presenter = index_presenter(document) %>
 <%# default partial to display solr document fields in catalog index view -%>
+
 <div class="document-metadata">
-  <% collection_member =  document['member_of_collections_ssim'] %>
+  <% collection_member = document['member_of_collections_ssim'] %>
   <% doc_presenter = index_presenter(document) %>
   <% if collection_member.present? %>
-    <% collection_member.each do |collection|%>
-      <p><%= render_collection_links(document) %></p>
-    <% end %>
+    <p><%= render_collection_links(document) %></p>
   <% end %>
   <% index_fields(document).each do |field_name, field| %>
-    <% if field_name == 'member_of_collections_ssim'  %>
+    <% if field_name == 'member_of_collections_ssim' %>
       <p><%= field %></p>
     <% end %>
   <% end %>

--- a/app/views/catalog/_index_list_default.html.erb
+++ b/app/views/catalog/_index_list_default.html.erb
@@ -6,7 +6,7 @@
   <% if document.to_h["has_model_ssim"].first != 'Collection' %>
     <div class="search-results-row">
       <h4 class="search-result-title">
-        <%= search_link(document, request)  %>
+        <%= search_link(document, request) %>
       </h4>
       <% if document.abstract.present? %>
         <div class="abstract-search-results">
@@ -19,15 +19,13 @@
     <div class="col-md-10 collection-member">
       <div class="metadata">
         <div>
-          <% collection_member =  document['member_of_collections_ssim'] %>
+          <% collection_member = document['member_of_collections_ssim'] %>
           <% doc_presenter = index_presenter(document) %>
           <% if collection_member.present? %>
-            <% collection_member.each do |collection|%>
-              <p><%= render_collection_links(document) %></p>
-            <% end %>
+            <p><%= render_collection_links(document) %></p>
           <% end %>
           <% index_fields(document).each do |field_name, field| %>
-            <% if field_name == 'member_of_collections_ssim'  %>
+            <% if field_name == 'member_of_collections_ssim' %>
               <p><%= field %></p>
             <% end %>
           <% end %>


### PR DESCRIPTION
### Summary
Prior to this commit, the rendering of "Is part of <collection name>"
was rendering twice. This commit corrects that and fixes some extra
spaces.

### Related Ticket
[#64 - Search Results](https://github.com/scientist-softserv/utk-hyku/issues/64)

### Screenshot
![image](https://user-images.githubusercontent.com/39319859/213823726-a66f78e3-878b-4c30-8b50-63d2c9b4bc08.png)
