### PR TITLE
i259 Browse Collections - All Collections List View | Show inner scroll bar for browse collections section

### DIFF
--- a/app/assets/stylesheets/themes/dc_repository.scss
+++ b/app/assets/stylesheets/themes/dc_repository.scss
@@ -682,20 +682,10 @@ body.dc_repository {
       .tab-content {
         .tab-pane {
           // Browse Collections Section Scroll
-
-          // Leaving this code here but commented out in case client changes mind on showing the inner scroll bar.
-          // hide scroll bar
-          // .scroll::-webkit-scrollbar {
-          //   display: none; /* Safari and Chrome */
-          // }
-
           .scroll {
             height: 1000px;
             overflow-x: hidden;
             overflow-y: auto;
-            // hide scroll bar
-            // -ms-overflow-style: none; /* Internet Explorer 10+ */
-            // scrollbar-width: none; /* Firefox */
           }
 
           // List view

--- a/app/assets/stylesheets/themes/dc_repository.scss
+++ b/app/assets/stylesheets/themes/dc_repository.scss
@@ -683,18 +683,19 @@ body.dc_repository {
         .tab-pane {
           // Browse Collections Section Scroll
 
+          // Leaving this code here but commented out in case client changes mind on showing the inner scroll bar.
           // hide scroll bar
-          .scroll::-webkit-scrollbar {
-            display: none; /* Safari and Chrome */
-          }
+          // .scroll::-webkit-scrollbar {
+          //   display: none; /* Safari and Chrome */
+          // }
 
           .scroll {
-            height: 800px;
+            height: 1000px;
             overflow-x: hidden;
             overflow-y: auto;
             // hide scroll bar
-            -ms-overflow-style: none; /* Internet Explorer 10+ */
-            scrollbar-width: none; /* Firefox */
+            // -ms-overflow-style: none; /* Internet Explorer 10+ */
+            // scrollbar-width: none; /* Firefox */
           }
 
           // List view


### PR DESCRIPTION
## Summary
Update to show inner scroll bar for browse collections section on the homepage.

## Related Ticket
[i259 - Browse Collections - All Collections List View](https://github.com/scientist-softserv/utk-hyku/issues/259)

## Screenshot
![Screenshot 2023-01-23 at 1 02 11 PM](https://user-images.githubusercontent.com/39319859/214150689-e6fc1971-6207-42af-8703-074b38315ead.JPG)

## QA Instructions
These changes only apply to the DC Repository theme - all other themes should have default styling
- Test on staging at https://dc.utk-hyku-staging.notch8.cloud/
- [ ] Inner scroll bar should be visible for browse collections section on the homepage