### PR TITLE
i57 Work show page - Update styles for active breadcrumb

### DIFF
--- a/app/assets/stylesheets/themes/dc_show.scss
+++ b/app/assets/stylesheets/themes/dc_show.scss
@@ -4,8 +4,8 @@ body.dc_show {
     margin-top: 0;
     padding: $golden-ratio-1 $golden-ratio-2;
 
-    a,
-    a:active {
+    li,
+    li:active {
       font-size: $type-2;
     }
   }


### PR DESCRIPTION
## Summary
Initially the active breadcrumb was a larger font size than the others in the group. This PR makes all the breadcrumbs the same font size.

## Screenshots
**Before**
![logged in breadcrumb large font on file name](https://user-images.githubusercontent.com/39319859/217381109-4385143f-d2e9-468a-8499-bbfdbcccf2d2.JPG)

**After**
![image](https://user-images.githubusercontent.com/39319859/217381175-fc534b1a-33fa-4142-8079-5b173770f580.png)

## Related Ticket
[#57 - Work Show Page](https://github.com/scientist-softserv/utk-hyku/issues/57)