### PR TITLE
i64 Search Results - Updates facet title font color

### DIFF
--- a/app/assets/stylesheets/themes/dc_repository.scss
+++ b/app/assets/stylesheets/themes/dc_repository.scss
@@ -1031,8 +1031,10 @@ body.dc_repository {
           color: $smokeyx;
 
           h3 {
-            color: $smokey !important;
             font-size: $type-3;
+            a {
+              color: $smokey !important;
+            }
           }
 
           .panel-title:after {


### PR DESCRIPTION
## Summary
On the search results page the facets heading color was globe blue and it should have been smokey grey. This PR corrects this.

## Related Ticket
[#64 Search Results](https://github.com/scientist-softserv/utk-hyku/issues/64)
## Screenshots

**Before**
![before](https://user-images.githubusercontent.com/39319859/217390970-481187ba-2be1-41e5-915f-b6e41cdcf832.JPG)

**After**
![after](https://user-images.githubusercontent.com/39319859/217390986-601096d3-6074-4b0f-9872-63b1de0659fb.JPG)
![after clicked](https://user-images.githubusercontent.com/39319859/217391000-048c3696-fe0c-430b-8b58-8342bd221dc0.JPG)

## QA Instructions
- These changes only apply to the DC Repository theme - all other themes should have default styling
- Test on staging at https://dc.utk-hyku-staging.notch8.cloud/
- In Admin dashboard under Appearance/Theme/DC Repository the DC View should be selected from the Search Results Page Theme dropdown
- [ ] On the search results page - Facets font color is dark grey like the above screenshot

