### PR TITLE
i64 Search Results - Update style for facet values more_facets_link

### DIFF
--- a/app/assets/stylesheets/themes/dc_repository.scss
+++ b/app/assets/stylesheets/themes/dc_repository.scss
@@ -1051,7 +1051,8 @@ body.dc_repository {
             background-color: transparent;
 
             .facet-values {
-              li .selected {
+              li .selected,
+              li .more_facets_link {
                 color: $globe;
                 font-size: $type-3;
               }


### PR DESCRIPTION
## Summary
On the search results page the facets value more_facets_link has the incorrect font size. This PR corrects this.

## Related Ticket
[#64 Search Results](https://github.com/scientist-softserv/utk-hyku/issues/64)

## Screenshots

**Before**
![before](https://user-images.githubusercontent.com/39319859/217598291-f27db2a2-9818-41a6-ab20-1bed9a5b9aa1.JPG)

**After**
![after](https://user-images.githubusercontent.com/39319859/217598312-37c8122a-8fee-45bc-8aee-235875d87838.JPG)


## QA Instructions
- These changes only apply to the DC Repository theme - all other themes should have default styling
- Test on staging at https://dc.utk-hyku-staging.notch8.cloud/
- In Admin dashboard under Appearance/Theme/DC Repository the DC View should be selected from the Search Results Page Theme dropdown
- [ ] On the search results page - Facets "more >>" is the same font size as the other menu items like the above screenshot
