### PR TITLE
i57 Work Show Page Metadata Section

### DIFF
--- a/app/assets/stylesheets/themes/dc_show.scss
+++ b/app/assets/stylesheets/themes/dc_show.scss
@@ -53,7 +53,7 @@ body.dc_show {
 
     .panel-heading {
       border-bottom: 1px solid $gray-3;
-      padding: 10px 0;
+      padding: $golden-ratio-1 0;
 
       .panel-title {
         font-size: $type-5;
@@ -64,7 +64,7 @@ body.dc_show {
       .work-show {
         dt {
           font-size: $type-3;
-          padding-top: 10px;
+          padding-top: $golden-ratio-1;
         }
 
         .tabular {
@@ -74,12 +74,61 @@ body.dc_show {
         }
       }
 
+      .attribute-abstract {
+        text-align: justify;
+        padding-top: $golden-ratio-1;
+      }
+
+      .work-show.metadata-block {
+        .metadata-group {
+          display: flex;
+          align-items: center;
+          padding: $golden-ratio-1;
+
+          dl {
+            overflow: hidden;
+            width: 100%;
+            padding: 0;
+            margin: 0;
+          }
+          dt {
+            float: left;
+            width: 30%;
+            padding: $golden-ratio-0 0;
+            margin: 0 !important;
+          }
+          dd {
+            float: left;
+            width: 70%;
+            padding: $golden-ratio-0 0;
+            margin: 0;
+
+            ul.tabular {
+              padding: 0;
+              margin: 0;
+
+              .attribute {
+                font-size: $type-3;
+              }
+            }
+          }
+        }
+        .metadata-group:nth-child(even) {
+          background-color: $gray-0;
+          border-radius: 5px;
+        }
+        .metadata-group:nth-child(odd) {
+          background-color: $white;
+          border-radius: 5px;
+        }
+      }
+
       .table {
         border-collapse: collapse;
 
         th {
           font-size: $type-3;
-          background-color: $gray-1;
+          background-color: $gray-0;
         }
 
         th:first-child {
@@ -94,32 +143,6 @@ body.dc_show {
           .attribute {
             font-size: $type-3;
             padding: $golden-ratio-3 $golden-ratio-0;
-          }
-        }
-      }
-
-      .metadata-group {
-        padding: 11px;
-        dl {
-          overflow: hidden;
-          width: 100%;
-          padding: 0;
-          margin: 0;
-        }
-        dt {
-          float: left;
-          width: 30%;
-          padding: 0;
-          margin: 0;
-        }
-        dd {
-          float: left;
-          width: 70%;
-          padding: 0;
-          margin: 0;
-
-          ul {
-            padding: 0;
           }
         }
       }
@@ -170,6 +193,16 @@ body.dc_show {
       .panel-heading {
         .panel-title {
           font-size: $type-4 !important;
+        }
+      }
+    }
+
+    .panel-body {
+      .work-show.metadata-block {
+        .metadata-group {
+          dd {
+            padding: $golden-ratio-0 0 $golden-ratio-0 $golden-ratio-2 !important;
+          }
         }
       }
     }

--- a/app/views/themes/dc_show/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/themes/dc_show/hyrax/base/_attribute_rows.html.erb
@@ -1,0 +1,12 @@
+<%# OVERRIDE: Hyrax v3.4.2 - add partial for custom theming of dc_repository theme %>
+
+<% presenter.dynamic_schema_service.view_properties.each_pair do | prop_key, prop_value | %>
+  <%# @todo internationalisation %>
+  <% next if prop_value[:admin_only] && !presenter.current_ability.current_user.admin? %>
+  <% value = presenter.attribute_to_html(prop_key, label: prop_value[:label], html_dl: true) %>
+  <% if value.present? && (prop_key != :abstract) %>
+    <div class='metadata-group'>
+      <%= value %>
+    </div>
+  <% end %>  
+<% end %>

--- a/app/views/themes/dc_show/hyrax/base/_metadata.html.erb
+++ b/app/views/themes/dc_show/hyrax/base/_metadata.html.erb
@@ -1,0 +1,7 @@
+<%# OVERRIDE: Hyrax v3.4.2 - add class for custom theming of dc_repository theme %>
+
+<dl class="work-show metadata-block <%= dom_class(presenter) %>" <%= presenter.microdata_type_to_html %>>
+  <%= render 'attribute_rows', presenter: presenter %>
+  <%= presenter.attribute_to_html(:embargo_release_date, render_as: :date, html_dl: true) %>
+  <%= presenter.attribute_to_html(:lease_expiration_date, render_as: :date, html_dl: true) %>
+</dl>

--- a/app/views/themes/dc_show/hyrax/base/show.html.erb
+++ b/app/views/themes/dc_show/hyrax/base/show.html.erb
@@ -46,9 +46,7 @@
           <h3 class="panel-title">Item Details</h3>
         </div>
         <div class="panel-body col-sm">
-          <div class="metadata-group">
-            <%= render 'metadata', presenter: @presenter %>
-          </div>
+          <%= render 'metadata', presenter: @presenter %>
         </div>
       </div>
       <div class="works-panel">


### PR DESCRIPTION
## Summary
Before this PR the metadata table was not rendering correctly and the abstract for the work was showing in this section. This PR addresses the rendered table data and styles.

## Related Ticket
[#57 - Work Show Page](https://github.com/scientist-softserv/utk-hyku/issues/57)

## Screenshots
<details>
<summary><strong>Before this PR</strong></summary>
<img src="https://user-images.githubusercontent.com/39319859/218182582-22d519d1-d27c-47ce-9ee8-8ed08b1fcbb0.JPG"/>
</details>

<details>
<summary><strong>After this PR</strong></summary>

<details>
<summary><strong>Full Screen</strong></summary>
<img src="https://user-images.githubusercontent.com/39319859/218200943-dbfa511a-43a3-4aa0-848e-9e5065f902b3.JPG"/>
</details>

<details>
<summary><strong>991px Screen</strong></summary>
<img src="https://user-images.githubusercontent.com/39319859/218201295-666ad993-aeac-4032-bea8-605c59f7b40f.JPG"/>
</details>

<details>
<summary><strong>767px Screen</strong></summary>
<img src="https://user-images.githubusercontent.com/39319859/218201510-32b7c646-2842-4563-8f41-32070c1c029e.JPG"/>
</details>
</details>

## QA Instructions
- These changes only apply to the DC Repository theme - all other themes should have default styling
- Test on staging at https://dc.utk-hyku-staging.notch8.cloud/
- In Admin dashboard under Appearance/Theme 
- [ ] Home Page Theme - choose DC Repository
- [ ] Search Results Page Theme dropdown - choose DC view
- [ ] Show Page Theme - choose DC Show Page
- Page looks like above screenshots at the following breakpoints
- [ ] full screen
- [ ] 991px
- [ ] 767px