### PR TITLE
i329 DC Log In Page

### DIFF
--- a/app/assets/stylesheets/themes/dc_repository.scss
+++ b/app/assets/stylesheets/themes/dc_repository.scss
@@ -1,6 +1,6 @@
 body.dc_repository {
   background-color: $white;
-  font-size: $type-4;
+  font-size: $type-3;
   color: $smokey !important;
   line-height: 35px;
   height: 100vh;
@@ -16,31 +16,19 @@ body.dc_repository {
   }
 
   h1 {
-    font-size: 40px;
     font-weight: 500;
   }
 
   h2 {
-    font-size: 32px;
     font-weight: 500;
   }
 
-  h3 {
-    font-size: 28px;
-  }
-
   h4 {
-    font-size: 24px;
     font-weight: 300;
-  }
-
-  h5 {
-    font-size: 20px;
   }
 
   h6 {
     font-family: "Gotham" !important;
-    font-size: 16px;
     text-transform: uppercase;
     color: $smokeyx !important;
     letter-spacing: 1pt;
@@ -107,7 +95,6 @@ body.dc_repository {
       padding: 0;
       width: auto;
       height: 100%;
-      // position: absolute;
     }
 
     #logo {
@@ -123,8 +110,6 @@ body.dc_repository {
     }
 
     #library-link {
-      // position: absolute;
-      // display: block;
       height: 100%;
       line-height: $golden-ratio-5;
       font-size: $type-5 !important;
@@ -189,7 +174,7 @@ body.dc_repository {
 
   #user_utility_links {
     display: flex;
-
+    // TODO Save for header ticket - double check these styles
     li.dropdown.header-actions-item {
       flex-grow: 0;
       flex-shrink: 1;
@@ -219,7 +204,7 @@ body.dc_repository {
       align-self: center;
       color: $rock !important;
     }
-
+    // TODO Save for header ticket - Menu not being used. display: none
     a#utk-lib-menu {
       display: block;
     }
@@ -464,7 +449,7 @@ body.dc_repository {
     width: 100%;
     height: 275px !important;
     min-height: 275px !important;
-    margin-bottom: $golden-ratio-4;
+    margin-bottom: $golden-ratio-3;
 
     .utk-digital-elements-wrapper {
       background-color: rgba(0, 108, 148, 0.95);
@@ -526,6 +511,7 @@ body.dc_repository {
         align-self: center;
         line-height: 1.29em;
         letter-spacing: -0.029em;
+        font-size: $type-4;
 
         a,
         a:visited {
@@ -1592,6 +1578,8 @@ body.dc_repository {
     }
 
     .title-masthead {
+      height: auto !important;
+      min-height: 225px !important;
       .navbar-nav {
         display: block;
       }

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,0 +1,29 @@
+<%# OVERRIDE /usr/local/bundle/gems/devise-i18n-1.10.2/app/views/devise/sessions/new.html.erb to add customization to log in page %>
+
+<h2 class="">Log in</h2>
+<div class="row">
+  <div class="col-md-4">
+    <%= form_for(resource, as: resource_name, url: session_path(resource_name), class: "form-horizontal") do |f| %>
+      <div class="form-group">
+        <%= f.label :email %><br />
+        <%= f.email_field :email, autofocus: true, class: "form-control" %>
+      </div>
+      <div class="form-group">
+        <%= f.label :password, class: "control-label" %><br />
+        <%= f.password_field :password, autocomplete: "off", class: "form-control" %>
+      </div>
+      <% if devise_mapping.rememberable? -%>
+        <div class="form-group">
+          <%= f.check_box :remember_me %>
+          <%= f.label :remember_me, class: "control-label" %>
+        </div>
+      <% end -%>
+      <div class="form-group">
+        <%= f.submit "Log in", class: 'btn btn-primary devise-button' %>
+      </div>
+    <% end %>
+    <div class="">
+      <%= render "devise/shared/links" %>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## Summary
Before this PR the sizing and spacing for the log in page were off. This PR addresses this by adding an override view file for devise and updates styles.

## Related Ticket
- https://github.com/scientist-softserv/utk-hyku/issues/329

## Screenshots
<details>
<summary><strong>Before this PR</strong></summary>
<img src="https://user-images.githubusercontent.com/39319859/217617477-34ef7a9c-cec1-469c-af71-96c55138856f.JPG"/>
</details>

<details>
<summary><strong>After this PR</strong></summary>

<details>
<summary><strong>Full Screen</strong></summary>
<img src="https://user-images.githubusercontent.com/39319859/219111413-c6c1c9e4-a2a4-409e-9e90-e535326477be.JPG"/>
</details>

<details>
<summary><strong>Medium Screen</strong></summary>
<img src="https://user-images.githubusercontent.com/39319859/219111502-c7970edf-efdf-4f13-874e-0cbfe56071f8.JPG"/>
</details>

<details>
<summary><strong>Small Screen</strong></summary>
<img src="https://user-images.githubusercontent.com/39319859/219111693-326a2a6c-6a6e-4988-a144-d371c8d7d56a.JPG"/>
</details>
</details>

## QA Instructions
- These changes only apply to the DC Repository theme - all other themes should have default styling
- Test on staging at https://dc.utk-hyku-staging.notch8.cloud/
- In Admin dashboard under Appearance/Theme 
- [x] Home Page Theme - choose DC Repository
- [x] Search Results Page Theme dropdown - choose DC view
- [x] Show Page Theme - choose DC Show Page
- Page looks like above screenshots at the following breakpoints
- [x] full screen
- [x] med screen
- [x] small screen