### PR TITLE
i57 Work Show Page - Abstract text alignment adjustment

### DIFF
--- a/app/assets/stylesheets/themes/dc_show.scss
+++ b/app/assets/stylesheets/themes/dc_show.scss
@@ -75,7 +75,6 @@ body.dc_show {
       }
 
       .attribute-abstract {
-        text-align: justify;
         padding-top: $golden-ratio-1;
       }
 


### PR DESCRIPTION
## Summary
This change is the result of the following client comment:
![image](https://user-images.githubusercontent.com/39319859/219763916-fdfbaade-4c7d-4888-a986-24827e0df11c.png)

Before this PR the abstract text was being aligned to justify. This PR addresses the text alignment of the abstract to be aligned left(default).

## Related Ticket
[#57 - Work Show Page](https://github.com/scientist-softserv/utk-hyku/issues/57)

## Screenshots
<details>
<summary><strong>Before this PR</strong></summary>
<img src="https://user-images.githubusercontent.com/39319859/219761611-5190dfe3-06a9-4058-8323-f996ae031066.JPG"/>
</details>

<details>
<summary><strong>After this PR</strong></summary>

<details>
<summary><strong>Full Screen</strong></summary>
<img src="https://user-images.githubusercontent.com/39319859/219762393-802708d4-e780-4ee0-9db5-34bdf564231d.JPG"/>
</details>

<details>
<summary><strong>991px Screen</strong></summary>
<img src="https://user-images.githubusercontent.com/39319859/219761793-f19122d4-239a-4a43-b199-debaf06ceb0e.JPG"/>
</details>

<details>
<summary><strong>767px Screen</strong></summary>
<img src="https://user-images.githubusercontent.com/39319859/219761951-8e81b7d2-6e4f-4495-90b8-f693f8ffa382.JPG"/>
</details>
</details>

## QA Instructions
- These changes only apply to the DC Repository theme - all other themes should have default styling
- Test on staging at https://dc.utk-hyku-staging.notch8.cloud/
- In Admin dashboard under Appearance/Theme 
- [ ] Home Page Theme - choose DC Repository
- [ ] Search Results Page Theme dropdown - choose DC view
- [ ] Show Page Theme - choose DC Show Page
- Page looks like above screenshots at the following breakpoints - Paying attention to abstract text.
- [ ] full screen
- [ ] 991px
- [ ] 767px