### PR TITLE
i347 - update bulkrax to pull in memory leak fix

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ GIT
 
 GIT
   remote: https://github.com/samvera-labs/bulkrax.git
-  revision: 74576c457909f56e4f2a42cede113bbadcdeedf9
+  revision: 491a6ae6fbaac644f2b735f7a07ce23dc19ef0bf
   branch: main
   specs:
     bulkrax (5.0.0)


### PR DESCRIPTION
ref: https://github.com/samvera-labs/bulkrax/pull/743

This MR upgrades bulkrax to pull in the memory leak fix. 

### PROBLEM: 

The client noticed that some but not all of their works were being attached to a collection, via a very large importer. The client expected 15,062 items in their collection, but noticed that the jobs would suddenly disappear and never finish creating relationships. 

With help from Rob and Jeremy, we discovered it was because of a memory leak. Once it hit 7g, the sidekiq container would fall over because it ran out of memory. 

### SOLUTION:

This was resolved by adding an uncached method to ActiveRecord, as mentioned in this [article](https://stackoverflow.com/questions/6668875/ruby-on-rails-memory-leak-when-looping-through-large-number-of-records-find-eac). 

Thankfully, when logging into the production shell we discovered that the pending relationship jobs were still present. So after implementing this code change, we manually re triggered the job and monitored the memory usage.

## AFTER

All of the relationships successfully formed. 🎉 
<img width="1266" alt="image (2)" src="https://user-images.githubusercontent.com/10081604/220214879-72199d75-34dd-4a5a-a904-b560e98e0be7.png">

<img width="1424" alt="image (1)" src="https://user-images.githubusercontent.com/10081604/220214871-141cec38-a021-4c06-bf72-33b005a71c94.png">


<img width="1439" alt="image" src="https://user-images.githubusercontent.com/10081604/220214824-fb1de6b1-5dd7-4061-9e65-aa407005633e.png">




