### PR TITLE
i332 DC Contact Page

### DIFF
--- a/app/assets/stylesheets/themes/dc_repository.scss
+++ b/app/assets/stylesheets/themes/dc_repository.scss
@@ -1336,6 +1336,21 @@ body.dc_repository {
   }
   /**** End Footers ****/
 
+  /**** Contact Page ****/
+  .contact-form {
+    h1 {
+      margin: $golden-ratio-3 0;
+    }
+    form {
+      flex-direction: column;
+
+      .contact-submit-btn {
+        align-self: flex-end;
+      }
+    }
+  }
+  /**** End Contact Page ****/
+
   /**** Responsive Styles ****/
   @media (min-width: 1200px) {
     // Header
@@ -1727,12 +1742,27 @@ body.dc_repository {
         max-width: 80%;
       }
     }
+
+    // Contact Page
+    .contact-form {
+      .alert-info {
+        font-size: $type-2;
+        line-height: $type-4;
+      }
+      h1 {
+        font-size: $type-5;
+      }
+      .form-group {
+        .contact-label {
+          padding-right: 10px;
+        }
+      }
+    }
   }
 
   @media (max-width: 767px) {
     // Search Results
     .search-container {
-      margin-bottom: $golden-ratio-2 !important;
       width: 85%;
       display: flex;
       flex-direction: column;

--- a/app/controllers/hyrax/contact_form_controller.rb
+++ b/app/controllers/hyrax/contact_form_controller.rb
@@ -14,7 +14,7 @@ module Hyrax
     include Blacklight::SearchHelper
     include Blacklight::AccessControls::Catalog
     before_action :build_contact_form
-    layout 'homepage'
+    layout 'dc_repository_contact'
 
     # OVERRIDE: Adding inject theme views method for theming
     around_action :inject_theme_views

--- a/app/views/layouts/dc_repository_contact.html.erb
+++ b/app/views/layouts/dc_repository_contact.html.erb
@@ -1,0 +1,31 @@
+<%# OVERRIDE: Hyrax v3.4.2 - add classes for custom design of dc repository theme %>
+<!-- add body classes to make styling easier -->
+
+<!DOCTYPE html>
+<html lang="<%= I18n.locale.to_s %>" prefix="og:http://ogp.me/ns#">
+  <head>
+    <%= render partial: 'layouts/head_tag_content' %>
+    <%= content_for(:head) %>
+  </head>
+  <% content_for(:extra_body_classes, 'public-facing utk-public-facing') unless params[:controller].match(/^proprietor/) %>
+  <body class="<%= body_class %> <%= home_page_theme %> <%= search_results_theme %> <%= show_page_theme %>">
+    <%= render_gtm_body(request.original_url) %>
+    <div class="skip-to-content">
+      <%= link_to "Skip to Content", "#skip-to-content" %>
+    </div>
+    <%= render '/themes/dc_repository/shared/subpage_header' %>
+    <%= content_for(:navbar) %>
+    <%= content_for(:precontainer_content) %>
+    <div id="content-wrapper" class="container search-container contact-container" role="main">
+      <%= render '/flash_msg' %>
+      <a name="skip-to-content" id="skip-to-content"></a>
+      <%= render 'shared/read_only' if Flipflop.read_only? %>
+      <div class='contact-form'>
+        <%= content_for?(:content) ? yield(:content) : yield %>
+      </div>
+    </div>
+    <!-- /#content-wrapper -->
+    <%= render '/themes/dc_repository/shared/footer' %>
+    <%= render 'shared/ajax_modal' %>
+  </body>
+</html>

--- a/app/views/themes/dc_repository/hyrax/contact_form/new.html.erb
+++ b/app/views/themes/dc_repository/hyrax/contact_form/new.html.erb
@@ -1,0 +1,52 @@
+<%# OVERRIDE: Hyrax v3.4.2 - add classes for custom design of dc repository theme %>
+
+<% provide :page_title, I18n.t('hyrax.contact_form.title') %>
+
+<div class="alert alert-info">
+  <%= render 'directions' %>
+</div>
+
+<h1>
+    <%= t('hyrax.contact_form.header') %>
+</h1>
+
+<% if user_signed_in? %>
+  <% nm = current_user.name %>
+  <% em = current_user.email %>
+<% else %>
+  <% nm = '' %>
+  <% em = '' %>
+<% end %>
+
+<%= form_for @contact_form, url: hyrax.contact_form_index_path,
+                            html: { class: 'form-horizontal d-flex' } do |f| %>
+  <%= f.text_field :contact_method, class: 'hide' %>
+  <div class="form-group">
+    <%= f.label :category, t('hyrax.contact_form.type_label'), class: "col-sm-2 control-label contact-label" %>
+    <div class="col-sm-10">
+      <%= f.select 'category', options_for_select(contact_form_issue_type_options), { include_blank: t('hyrax.contact_form.select_type') }, {class: 'form-control', required: true } %>
+    </div>
+  </div>
+
+  <div class="form-group">
+    <%= f.label :name, t('hyrax.contact_form.name_label'), class: "col-sm-2 control-label contact-label" %>
+    <div class="col-sm-10"><%= f.text_field :name, value: nm, class: 'form-control', required: true %></div>
+  </div>
+
+  <div class="form-group">
+    <%= f.label :email, t('hyrax.contact_form.email_label'), class: "col-sm-2 control-label contact-label" %>
+    <div class="col-sm-10"><%= f.text_field :email, value: em, class: 'form-control', required: true %></div>
+  </div>
+
+  <div class="form-group">
+    <%= f.label :subject, t('hyrax.contact_form.subject_label'), class: "col-sm-2 control-label contact-label" %>
+    <div class="col-sm-10"><%= f.text_field :subject, class: 'form-control', required: true %></div>
+  </div>
+
+  <div class="form-group">
+    <%= f.label :message, t('hyrax.contact_form.message_label'), class: "col-sm-2 control-label contact-label" %>
+    <div class="col-sm-10"><%= f.text_area :message, rows: 4, class: 'form-control', required: true %></div>
+  </div>
+
+  <%= f.submit value: t('hyrax.contact_form.button_label'), class: "btn btn-primary contact-submit-btn" %>
+<% end %>


### PR DESCRIPTION
## Summary
This PR adds custom theming to the DC repository contact page.

## Related Ticket
- https://github.com/scientist-softserv/utk-hyku/issues/332

## Screenshots
<details>
<summary><strong>Before this PR</strong></summary>
<img src="https://user-images.githubusercontent.com/39319859/220990168-362f22f9-b91a-47ba-b586-fa2d0dcfe6e9.png"/>
</details>

<details>
<summary><strong>After this PR</strong></summary>

<details>
<summary><strong>Full Screen</strong></summary>
<img src="https://user-images.githubusercontent.com/39319859/220992483-aee38493-4084-4ead-b5b9-55d3d09f12b6.JPG"/>
</details>

<details>
<summary><strong>991px Screen</strong></summary>
<img src="https://user-images.githubusercontent.com/39319859/220992546-607a4fe0-e4ea-4010-af8f-553630449f4f.JPG"/>
</details>


<details>
<summary><strong>767px Screen</strong></summary>
<img src="https://user-images.githubusercontent.com/39319859/220992638-caaf40cf-e96e-4fcd-8a70-7fd367e18491.JPG"/>
</details>
</details>

## QA Instructions
- These changes only apply to the DC Repository theme - all other themes should have default styling
- Test on staging at https://dc.utk-hyku-staging.notch8.cloud/
- In Admin dashboard under Appearance/Theme 
- [ ] Home Page Theme - choose DC Repository
- [ ] Search Results Page Theme dropdown - choose DC view
- [ ] Show Page Theme - choose DC Show Page
- Page looks like above screenshots at the following breakpoints
- [ ] full screen
- [ ] 991px
- [ ] 767px