### PR TITLE
i333 DC About Page Layout

### DIFF
--- a/app/controllers/hyrax/pages_controller.rb
+++ b/app/controllers/hyrax/pages_controller.rb
@@ -10,7 +10,7 @@ module Hyrax
   # Shows the about and help page
   class PagesController < ApplicationController
     load_and_authorize_resource class: ContentBlock, except: :show
-    layout 'dc_repository_about'
+    layout :pages_layout
 
     # OVERRIDE: Hyrax v3.4.0 Add for theming
     # Adds Hydra behaviors into the application controller
@@ -84,7 +84,7 @@ module Hyrax
       end
 
       def pages_layout
-        action_name == 'show' ? 'homepage' : 'hyrax/dashboard'
+        action_name == 'show' ? 'dc_repository_about' : 'hyrax/dashboard'
       end
 
       # OVERRIDE: return collections for theming

--- a/app/controllers/hyrax/pages_controller.rb
+++ b/app/controllers/hyrax/pages_controller.rb
@@ -10,7 +10,7 @@ module Hyrax
   # Shows the about and help page
   class PagesController < ApplicationController
     load_and_authorize_resource class: ContentBlock, except: :show
-    layout :pages_layout
+    layout 'dc_repository_about'
 
     # OVERRIDE: Hyrax v3.4.0 Add for theming
     # Adds Hydra behaviors into the application controller

--- a/app/views/layouts/dc_repository_about.html.erb
+++ b/app/views/layouts/dc_repository_about.html.erb
@@ -1,0 +1,33 @@
+<%# OVERRIDE: Hyrax v3.4.2 - add classes for custom design of dc repository theme %>
+
+<!-- add body classes to make styling easier -->
+<!DOCTYPE html>
+<html lang="<%= I18n.locale.to_s %>" prefix="og:http://ogp.me/ns#">
+  <head>
+    <%= render partial: 'layouts/head_tag_content' %>
+    <%= content_for(:head) %>
+  </head>
+  <% content_for(:extra_body_classes, 'public-facing utk-public-facing') unless params[:controller].match(/^proprietor/) %>
+  <body class="<%= body_class %> <%= home_page_theme %> <%= search_results_theme %> <%= show_page_theme %>">
+    <%= render_gtm_body(request.original_url) %>
+    <div class="skip-to-content">
+      <%= link_to "Skip to Content", "#skip-to-content" %>
+    </div>
+    <%= render '/themes/dc_repository/shared/subpage_header' %>
+    <%= content_for(:navbar) %>
+    <%= content_for(:precontainer_content) %>
+    <div id="content-wrapper" class="container" role="main">
+      <%= render '/flash_msg' %>
+      <a name="skip-to-content" id="skip-to-content"></a>
+      <%= render 'shared/read_only' if Flipflop.read_only? %>
+      <div id='about'>
+        <div class='about-form'>
+          <%= content_for?(:content) ? yield(:content) : yield %>
+        </div>
+      </div>
+    </div>
+    <!-- /#content-wrapper -->
+    <%= render '/themes/dc_repository/shared/footer' %>
+    <%= render 'shared/ajax_modal' %>
+  </body>
+</html>

--- a/app/views/layouts/dc_repository_about.html.erb
+++ b/app/views/layouts/dc_repository_about.html.erb
@@ -1,4 +1,4 @@
-<%# OVERRIDE: Hyrax v3.4.2 - add classes for custom design of dc repository theme %>
+<%# OVERRIDE: Hyrax v3.4.2 - add custom partial to add classes and structure for custom design of dc repository theme about page %>
 
 <!-- add body classes to make styling easier -->
 <!DOCTYPE html>

--- a/app/views/layouts/dc_repository_about.html.erb
+++ b/app/views/layouts/dc_repository_about.html.erb
@@ -1,7 +1,7 @@
 <%# OVERRIDE: Hyrax v3.4.2 - add custom partial to add classes and structure for custom design of dc repository theme about page %>
 
-<!-- add body classes to make styling easier -->
 <!DOCTYPE html>
+<!-- add body classes to make styling easier -->
 <html lang="<%= I18n.locale.to_s %>" prefix="og:http://ogp.me/ns#">
   <head>
     <%= render partial: 'layouts/head_tag_content' %>


### PR DESCRIPTION
## Summary
This PR adds custom theming to the DC repository about page layout. **_The about page contents are not addressed in this PR._**

## Related Ticket
- https://github.com/scientist-softserv/utk-hyku/issues/333

## Screenshots
<details>
<summary><strong>Before this PR</strong></summary>
<img src="https://user-images.githubusercontent.com/39319859/221631382-97735ce1-d18b-4773-88dc-af437eeb8b4a.png"/>
</details>

<details>
<summary><strong>After this PR</strong></summary>


<img src="https://user-images.githubusercontent.com/39319859/221631742-fadf1bd1-85a9-4971-8fc0-56dde32876c2.png"/>



</details>

## QA Instructions
- These changes only apply to the DC Repository theme - all other themes should have default styling
- Test on staging at https://dc.utk-hyku-staging.notch8.cloud/
- In Admin dashboard under Appearance/Theme 
- [ ] Home Page Theme - choose DC Repository
- [ ] Search Results Page Theme dropdown - choose DC view
- [ ] Show Page Theme - choose DC Show Page
- Page header and footer on the About page looks like the above screenshots at the following breakpoints
- [ ] full screen
- [ ] 991px
- [ ] 767px