### PR TITLE
Adding `Hyrax::ConditionalDerivativeDecorator`

### DIFF
--- a/app/jobs/create_derivatives_job_decorator.rb
+++ b/app/jobs/create_derivatives_job_decorator.rb
@@ -3,8 +3,6 @@
 # OVERRIDE HYRAX 3.4.1 to skip derivative job unless rdf_type is "pcdm-muse:IntermediateFile"
 module Hyrax
   module CreateDerivativesJobDecorator
-    INTERMEDIATE_FILE = "IntermediateFile".downcase
-
     # @param [FileSet] file_set
     # @param [String] file_id identifier for a Hydra::PCDM::File
     # @param [String, NilClass] filepath the cached file within the Hyrax.config.working_path
@@ -19,7 +17,8 @@ module Hyrax
         return false
       end
 
-      return unless file_set.rdf_type&.join&.downcase&.include?(INTERMEDIATE_FILE)
+      # OVERRIDE HYRAX 3.4.1 to skip derivative job unless rdf_type is "pcdm-muse:IntermediateFile"
+      return unless Hyrax::ConditionalDerivativeDecorator.generate_derivatives_for?(file_set: file_set)
 
       # Ensure a fresh copy of the repo file's latest version is being worked on, if no filepath is directly provided
       unless filepath && File.exist?(filepath)

--- a/config/application.rb
+++ b/config/application.rb
@@ -37,14 +37,18 @@ module Hyku
         config.active_elastic_job.secret_key_base = Rails.application.secrets[:secret_key_base]
       end
     end
-    
+
     config.to_prepare do
       # Allows us to use decorator files in the app directory
       Dir.glob(Rails.root.join("app/**/*_decorator*.rb")).sort.each do |c|
         Rails.configuration.cache_classes ? require(c) : load(c)
       end
+
+      Dir.glob(Rails.root.join("lib/**/*_decorator*.rb")).sort.each do |c|
+        Rails.configuration.cache_classes ? require(c) : load(c)
+      end
     end
-    
+
     # resolve reloading issue in dev mode
     config.paths.add 'app/helpers', eager_load: true
 

--- a/lib/extensions/hyrax/conditional_derivative_decorator.rb
+++ b/lib/extensions/hyrax/conditional_derivative_decorator.rb
@@ -31,3 +31,6 @@ module Hyrax
     end
   end
 end
+
+# NOTE: Until we add the IIIF Print gem, this is adequate for short-circuiting running derivatives.
+Hyrax::FileSetDerivativesService.prepend(Hyrax::ConditionalDerivativeDecorator)

--- a/lib/extensions/hyrax/conditional_derivative_decorator.rb
+++ b/lib/extensions/hyrax/conditional_derivative_decorator.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Hyrax
+  module ConditionalDerivativeDecorator
+    INTERMEDIATE_FILE_TYPE_TEXT = "intermediatefile"
+
+    ##
+    # @api public
+    #
+    # @param file_set [FileSet]
+    # @param intermediate_file_type_text [String]
+    #
+    # @return [TrueClass] when we should generate derivatives for the given :file_set
+    # @return [FalseClass] when we should **not** generate derivatives for the given :file_set
+    def self.generate_derivatives_for?(file_set:, intermediate_file_type_text: INTERMEDIATE_FILE_TYPE_TEXT)
+      return true unless file_set.respond_to?(:rdf_type)
+      return false if file_set.rdf_type&.join&.downcase&.include?(intermediate_file_type_text)
+
+      true
+    end
+
+    ##
+    # @return [TrueClass] when the associated file_set should use the associated derivative
+    # @return [FalseClass] when the associated file_set should **not** use the associated derivative
+    #         service
+    def valid?
+      # Yes, I'm calling the module method :generate_derivatives_for? because that is logic likely
+      # to repeat elsewhere.
+      return false unless self.class.generate_derivatives_for?(file_set: file_set)
+      super
+    end
+  end
+end

--- a/spec/extensions/hyrax/conditional_derivative_decorator_spec.rb
+++ b/spec/extensions/hyrax/conditional_derivative_decorator_spec.rb
@@ -21,4 +21,8 @@ RSpec.describe Hyrax::ConditionalDerivativeDecorator do
       it { is_expected.to be_falsey }
     end
   end
+
+  it "is included in the Hyrax::FileSetDerivativesService modules" do
+    expect(Hyrax::FileSetDerivativesService.included_modules).to include(described_class)
+  end
 end

--- a/spec/extensions/hyrax/conditional_derivative_decorator_spec.rb
+++ b/spec/extensions/hyrax/conditional_derivative_decorator_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Hyrax::ConditionalDerivativeDecorator do
+  describe '.generate_derivatives_for?' do
+    subject { described_class.generate_derivatives_for?(file_set: file_set) }
+
+    let(:file_set) { double(FileSet, rdf_type: Array.wrap(rdf_type)) }
+    let(:rdf_type) { nil }
+
+    context "when none of file_set's the RDF types are \"IntermediateFile\"" do
+      let(:rdf_type) { ["Ketchup", "Sandwich"] }
+
+      it { is_expected.to be_truthy }
+    end
+
+    context "when one of the file_set's RDF types for the file is \"IntermediateFile\"" do
+      let(:rdf_type) { ["Ketchup", "IntermediateFile", "Sandwich"] }
+
+      it { is_expected.to be_falsey }
+    end
+  end
+end


### PR DESCRIPTION
## Adding `Hyrax::ConditionalDerivativeDecorator`

7a45265297b3dfe820993048bfd95a616eae4c2d

This commit begins to address we'll conditionally do things to address
issue #343.

Related to:

- https://github.com/scientist-softserv/utk-hyku/issues/343

## Guarding Hyrax::FileSetDerivativesService#valid?

e763f64b1b3205bfe50fb3eda486883098e7c0f2

Prior to this commit, the `Hyrax::FileSetDerivativesService#valid?`
method would have returned `true` even if we were not going to generate
derivatives for this work.  This is important because
`FileSet#create_deriatives` delegates to the service(s) of the
`Hyrax::DerivativeService` which are `valid? == true`.  In other words,
we could create a situation where someone might outside of the job
create a derivative for a file set that should not have a created
derivative.

With this commit, we are less likely to accidentally call
`Hyrax::FileSetDerivativesService#create_derivatives` (by way of
delegation from `FileSet#create_deriatives`).

Related to:

- https://github.com/scientist-softserv/utk-hyku/issues/343
