### PR TITLE
i335 DC File Set Show Page

### DIFF
--- a/app/assets/stylesheets/themes/dc_repository.scss
+++ b/app/assets/stylesheets/themes/dc_repository.scss
@@ -1351,6 +1351,28 @@ body.dc_repository {
   }
   /**** End Contact Page ****/
 
+  /**** File Set Show Page ****/
+  #dc-file-set {
+    header {
+      h1 {
+        font-size: $type-5;
+
+        span.label {
+          display: none;
+        }
+      }
+    }
+    h2 {
+      font-size: $type-4;
+    }
+    .form-actions {
+      .social-media {
+        display: none;
+      }
+    }
+  }
+  /**** End File Set Show Page ****/
+
   /**** Responsive Styles ****/
   @media (min-width: 1200px) {
     // Header
@@ -2025,6 +2047,17 @@ body.dc_repository {
             }
           }
         }
+      }
+    }
+    // File Set Show Page
+    #dc-file-set {
+      header {
+        h1 {
+          font-size: $type-4;
+        }
+      }
+      h2 {
+        font-size: $type-3;
       }
     }
   }

--- a/app/views/hyrax/file_sets/show.html.erb
+++ b/app/views/hyrax/file_sets/show.html.erb
@@ -1,0 +1,27 @@
+<%# OVERRIDE: Hyrax v3.4.2 - hyrax/app/views/hyrax/file_sets/show.html.erb to add id for custom styling of dc repository theme file set show page %>
+
+<% provide :page_title, @presenter.page_title %>
+<div id="dc-file-set" class="container-fluid">
+  <div class="row">
+    <div class="col-xs-12 col-sm-4">
+      <%= render media_display_partial(@presenter), file_set: @presenter %>
+      <%= render 'show_actions', presenter: @presenter %>
+      <%= render 'single_use_links', presenter: @presenter if @presenter.editor? %>
+    </div>
+    <div itemscope itemtype="<%= @presenter.itemtype %>" class="col-xs-12 col-sm-8">
+      <header>
+        <%= render 'file_set_title', presenter: @presenter %>
+      </header>
+      <%= render 'show_details' %>
+      <%= render 'hyrax/users/activity_log', events: @presenter.events %>
+    </div>
+    <!-- /columns second -->
+  </div>
+ <!-- /.row -->
+</div>
+<!-- /.container-fluid -->
+<% @presenter.member_of_collection_ids.each do |collection_id| %>
+  <span class='hide analytics-event' data-category="file-set-in-collection" data-action="file-set-in-collection-view" data-name="<%= collection_id %>" >
+  <% end %>
+  <span class='hide analytics-event' data-category="file-set-in-work" data-action="file-set-in-work-view" data-name="<%= @presenter.parent.id %>" >
+    <span class='hide analytics-event' data-category="file-set" data-action="file-set-view" data-name="<%= @presenter.id %>" >


### PR DESCRIPTION
## Summary
This PR adds custom theming to the DC repository file set show page.

## Related Ticket
- https://github.com/scientist-softserv/utk-hyku/issues/335

## Screencast

https://user-images.githubusercontent.com/39319859/222285446-de22b4db-f813-4cd4-bab2-12bec7d272c3.mp4

## QA Instructions
- These changes only apply to the DC Repository theme - all other themes should have default styling
- Test on staging file at https://dc.utk-hyku-staging.notch8.cloud/concern/file_sets/99a142ca-343f-4c51-a2ff-13b12a9be33b?locale=en
- In Admin dashboard under Appearance/Theme 
- [ ] Home Page Theme - choose DC Repository
- [ ] Search Results Page Theme dropdown - choose DC view
- [ ] Show Page Theme - choose DC Show Page
- File set show page looks like above screenshots at the following breakpoints
- [ ] full screen
- [ ] 991px
- [ ] 767px