### PR TITLE
Ensuring we're using the proper class for the test

### DIFF
--- a/lib/extensions/hyrax/conditional_derivative_decorator.rb
+++ b/lib/extensions/hyrax/conditional_derivative_decorator.rb
@@ -26,7 +26,7 @@ module Hyrax
     def valid?
       # Yes, I'm calling the module method :generate_derivatives_for? because that is logic likely
       # to repeat elsewhere.
-      return false unless self.class.generate_derivatives_for?(file_set: file_set)
+      return false unless ConditionalDerivativeDecorator.generate_derivatives_for?(file_set: file_set)
       super
     end
   end

--- a/spec/extensions/hyrax/conditional_derivative_decorator_spec.rb
+++ b/spec/extensions/hyrax/conditional_derivative_decorator_spec.rb
@@ -3,11 +3,11 @@
 require 'rails_helper'
 
 RSpec.describe Hyrax::ConditionalDerivativeDecorator do
+  let(:file_set) { double(FileSet, rdf_type: Array.wrap(rdf_type)) }
+  let(:rdf_type) { nil }
+
   describe '.generate_derivatives_for?' do
     subject { described_class.generate_derivatives_for?(file_set: file_set) }
-
-    let(:file_set) { double(FileSet, rdf_type: Array.wrap(rdf_type)) }
-    let(:rdf_type) { nil }
 
     context "when none of file_set's the RDF types are \"IntermediateFile\"" do
       let(:rdf_type) { ["Ketchup", "Sandwich"] }
@@ -19,6 +19,32 @@ RSpec.describe Hyrax::ConditionalDerivativeDecorator do
       let(:rdf_type) { ["Ketchup", "IntermediateFile", "Sandwich"] }
 
       it { is_expected.to be_falsey }
+    end
+  end
+
+  describe "mixing in module to base class" do
+    subject { model.new(file_set: file_set) }
+
+    let(:model) do
+      Class.new do
+        def initialize(file_set:)
+          @file_set = file_set
+        end
+        attr_reader :file_set
+        include Hyrax::ConditionalDerivativeDecorator
+      end
+    end
+
+    context "when none of file_set's the RDF types are \"IntermediateFile\"" do
+      let(:rdf_type) { ["Ketchup", "Sandwich"] }
+
+      it { is_expected.to be_valid }
+    end
+
+    context "when one of the file_set's RDF types for the file is \"IntermediateFile\"" do
+      let(:rdf_type) { ["Ketchup", "IntermediateFile", "Sandwich"] }
+
+      it { is_expected.not_to be_valid }
     end
   end
 


### PR DESCRIPTION
Prior to this commit, when we mixin the
`Hyrax::ConditionalDerivativeDecorator` the `self.class` becomes the base class (e.g. the receiver of the `.prepend Hyrax::ConditionalDerivativeDecorator`)

This creates a MethodMissing error.

With this commit, I'm switching from the `self.class` call to an explicit `ConditionalDerivativeDecorator`.

Related to:

- https://github.com/scientist-softserv/utk-hyku/issues/343
- https://github.com/scientist-softserv/utk-hyku/pull/353
