### PR TITLE
i352 Header Fixes

### DIFF
--- a/app/views/themes/dc_repository/_user_util_links.html.erb
+++ b/app/views/themes/dc_repository/_user_util_links.html.erb
@@ -26,10 +26,4 @@
     </li>
   <% end %>
   <%= render 'shared/locale_picker' if available_translations.size > 1 %>
-  <li class="header-actions-item">
-    <a id="utk-lib-menu" class="utk-menu utk-header-expand" href="#" aria-label="Expand Main Menu">
-    <span class="fa fa-solid fa-bars"></span>
-    <em>Menu</em>
-    </a>
-  </li>
 </ul>


### PR DESCRIPTION
## Summary
 Prior to this PR there was a menu element in the header that had no function. This PR removes the menu element from header.

## Related Ticket
- https://github.com/scientist-softserv/utk-hyku/issues/352

## Screenshots
**Full screen**
![Screenshot 2023-03-07 at 7 46 25 AM](https://user-images.githubusercontent.com/39319859/223473701-c7133c02-bcbd-4731-a4d3-ff682969757a.JPG)
**Med screen**
![Screenshot 2023-03-07 at 7 46 09 AM](https://user-images.githubusercontent.com/39319859/223473722-697bd9a6-31ac-420b-97fa-8b6de0a1a230.JPG)
**Sm screen**
![Screenshot 2023-03-07 at 7 45 54 AM](https://user-images.githubusercontent.com/39319859/223473744-3efab9b9-bd41-4bcc-b82a-d772b6f9d081.JPG)

## QA Instructions
- These changes only apply to the DC Repository theme - all other themes should have default styling
- Test on staging at https://dc.utk-hyku-staging.notch8.cloud/
- General breakpoints
- full screen
- 991px
- 767px