### PR TITLE
i352 Header Fixes - Update logo path

### DIFF
--- a/app/views/themes/dc_repository/_masthead.html.erb
+++ b/app/views/themes/dc_repository/_masthead.html.erb
@@ -6,7 +6,7 @@
     <!-- Brand and toggle get grouped for better mobile display -->
     <div class="navbar-header utk-logo-flex"> 
       <div class='utk-logo-wrapper'>
-        <%= render '/logo' %>
+        <%= render '/themes/dc_repository/logo' %>
         <a id="library-link" class="navbar-library-link" href="https://www.lib.utk.edu" data-no-turbolink="true">Libraries</a>
         </a>
       </div>


### PR DESCRIPTION
## Summary
The small logo was not rendering on smaller screens on some pages. This PR changes the logo path and now the logo resizes correctly on all pages.

## Screenshots
**After this ticket**
![image](https://user-images.githubusercontent.com/39319859/224405083-c5abd300-7f8e-4ff7-9470-1475b4cf4e52.png)

## QA Instructions
- These changes only apply to the DC Repository theme - all other themes should have default styling
- Test on staging at https://dc.utk-hyku-staging.notch8.cloud/
- The logo in the header for all pages changes from the full logo to the small "T" logo at the following breakpoints:
- [ ] 991px
- [ ] 767px
