### PR TITLE
Reverse conditional_derivative_decorator logic

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -95,7 +95,7 @@ gem 'blacklight_oai_provider', '~> 6.1', '>= 6.1.1'
 gem 'hyrax', git: 'https://github.com/samvera/hyrax.git', branch: '3.x-stable'
 # we need redlock to be at a lower version that Hyrax 3.x defines, otherwise it causes fileset attachment errors
 # ref: https://github.com/samvera/hyrax/blob/d83b8392e6a30c6ad4915a2f13d174de199afb07/hyrax.gemspec#L78
-gem 'redlock', '~>1.2.2' 
+gem 'redlock', '~>1.2.2'
 
 gem 'hyrax-iiif_av', git: 'https://github.com/samvera-labs/hyrax-iiif_av.git', branch: 'utk-hyku-with-hyrax-3'
 gem 'iiif_print', git: 'https://github.com/scientist-softserv/iiif_print.git', branch: 'main'

--- a/Gemfile
+++ b/Gemfile
@@ -93,6 +93,9 @@ gem 'blacklight_oai_provider', '~> 6.1', '>= 6.1.1'
 
 # lock to graph indexing update commit
 gem 'hyrax', git: 'https://github.com/samvera/hyrax.git', branch: '3.x-stable'
+# we need redlock to be at a lower version that Hyrax 3.x defines, otherwise it causes fileset attachment errors
+# ref: https://github.com/samvera/hyrax/blob/d83b8392e6a30c6ad4915a2f13d174de199afb07/hyrax.gemspec#L78
+gem 'redlock', '~>1.2.2' 
 
 gem 'hyrax-iiif_av', git: 'https://github.com/samvera-labs/hyrax-iiif_av.git', branch: 'utk-hyku-with-hyrax-3'
 gem 'iiif_print', git: 'https://github.com/scientist-softserv/iiif_print.git', branch: 'main'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,10 +10,10 @@ GIT
 
 GIT
   remote: https://github.com/samvera-labs/bulkrax.git
-  revision: 491a6ae6fbaac644f2b735f7a07ce23dc19ef0bf
+  revision: 09e8d2f05aa0822f544a8545cf263013ffd52d9a
   branch: main
   specs:
-    bulkrax (5.0.0)
+    bulkrax (5.1.0)
       bagit (~> 0.4)
       coderay
       iso8601 (~> 0.9.0)
@@ -115,7 +115,7 @@ GIT
 
 GIT
   remote: https://github.com/scientist-softserv/iiif_print.git
-  revision: ec8da2e7bb144b9daaaaf0770174f47f00f96fb8
+  revision: 683c06b6bd5b08fd8c712e67ab0184de4cad197a
   branch: main
   specs:
     iiif_print (1.0.0)
@@ -1016,12 +1016,10 @@ GEM
     redic (1.5.3)
       hiredis
     redis (4.7.1)
-    redis-client (0.14.0)
-      connection_pool
     redis-namespace (1.10.0)
       redis (>= 4)
-    redlock (2.0.1)
-      redis-client
+    redlock (1.2.2)
+      redis (>= 3.0.0, < 5.0)
     reform (2.5.0)
       disposable (>= 0.4.2, < 0.5.0)
       representable (>= 2.4.0, < 3.1.0)
@@ -1345,6 +1343,7 @@ DEPENDENCIES
   rails-controller-testing
   rdf (~> 3.1.15)
   react-rails
+  redlock (~> 1.2.2)
   riiif (~> 1.1)
   rolify
   rsolr (~> 2.0)

--- a/app/services/custom_derivative_service.rb
+++ b/app/services/custom_derivative_service.rb
@@ -3,7 +3,7 @@
 # @api public
 module CustomDerivativeService
   def valid?
-    false if file_set.rdf_type&.join&.downcase&.include?("intermediate_file")
+    true if file_set.rdf_type&.join&.downcase&.include?("intermediate_file")
   end
 end
 

--- a/lib/extensions/hyrax/conditional_derivative_decorator.rb
+++ b/lib/extensions/hyrax/conditional_derivative_decorator.rb
@@ -13,10 +13,7 @@ module Hyrax
     # @return [TrueClass] when we should generate derivatives for the given :file_set
     # @return [FalseClass] when we should **not** generate derivatives for the given :file_set
     def self.generate_derivatives_for?(file_set:, intermediate_file_type_text: INTERMEDIATE_FILE_TYPE_TEXT)
-      return true unless file_set.respond_to?(:rdf_type)
-      return false if file_set.rdf_type&.join&.downcase&.include?(intermediate_file_type_text)
-
-      true
+      file_set.try(:rdf_type)&.join&.downcase&.include?(intermediate_file_type_text)
     end
 
     ##

--- a/spec/extensions/hyrax/conditional_derivative_decorator_spec.rb
+++ b/spec/extensions/hyrax/conditional_derivative_decorator_spec.rb
@@ -12,13 +12,13 @@ RSpec.describe Hyrax::ConditionalDerivativeDecorator do
     context "when none of file_set's the RDF types are \"IntermediateFile\"" do
       let(:rdf_type) { ["Ketchup", "Sandwich"] }
 
-      it { is_expected.to be_truthy }
+      it { is_expected.to be_falsey }
     end
 
     context "when one of the file_set's RDF types for the file is \"IntermediateFile\"" do
       let(:rdf_type) { ["Ketchup", "IntermediateFile", "Sandwich"] }
 
-      it { is_expected.to be_falsey }
+      it { is_expected.to be_truthy }
     end
   end
 
@@ -38,13 +38,13 @@ RSpec.describe Hyrax::ConditionalDerivativeDecorator do
     context "when none of file_set's the RDF types are \"IntermediateFile\"" do
       let(:rdf_type) { ["Ketchup", "Sandwich"] }
 
-      it { is_expected.to be_valid }
+      it { is_expected.not_to be_valid }
     end
 
     context "when one of the file_set's RDF types for the file is \"IntermediateFile\"" do
       let(:rdf_type) { ["Ketchup", "IntermediateFile", "Sandwich"] }
 
-      it { is_expected.not_to be_valid }
+      it { is_expected.to be_valid }
     end
   end
 


### PR DESCRIPTION
ref #398 

This commit also address its spec however one of them do not pass and
will get addressed in a separated commit.

spec/extensions/hyrax/conditional_derivative_decorator_spec.rb:15 gives a false positve

spec/extensions/hyrax/conditional_derivative_decorator_spec.rb:21 does not pass

### I created an attachment w intermediate file type and attached a file set to it. The file set should render a thumbnail. ✅ 

![image](https://user-images.githubusercontent.com/10081604/228678859-2542b1c2-5f97-4d1f-bf9d-e193a65cb877.png)

![image](https://user-images.githubusercontent.com/10081604/228679108-5f667193-4e2c-4beb-b363-db15c3e19ec3.png)


### I created an attachment that's not an intermediate file type and attached a file set to it. The file set should NOT render a thumbnail. ✅ 

![image](https://user-images.githubusercontent.com/10081604/228679527-8ade0757-6e70-46ce-809e-82e604771ebf.png)

![image](https://user-images.githubusercontent.com/10081604/228679731-b4b5112f-ec0c-42e4-8d4c-be51aaff747a.png)
