### PR TITLE
i398 - Fix string

### DIFF
--- a/app/services/custom_derivative_service.rb
+++ b/app/services/custom_derivative_service.rb
@@ -3,7 +3,7 @@
 # @api public
 module CustomDerivativeService
   def valid?
-    true if file_set.rdf_type&.join&.downcase&.include?("intermediate_file")
+    file_set.rdf_type&.join&.downcase&.include?(Hyrax::ConditionalDerivativeDecorator::INTERMEDIATE_FILE_TYPE_TEXT)
   end
 end
 


### PR DESCRIPTION
ref: #398 

Prior to this commit, the string that was being read was `intermediate_file` instead of `intermediatefile`.  This commit will reference
`Hyrax::ConditionalDerivativeDecorator::INTERMEDIATE_FILE_TYPE_TEXT` for that magical string.
