### PR TITLE
update-cpu-values-to-milicpu

### DIFF
--- a/ops/production-deploy.tmpl.yaml
+++ b/ops/production-deploy.tmpl.yaml
@@ -2,11 +2,11 @@ replicaCount: 2
 
 resources:
   limits:
-    memory: "4GB"
-    cpu: "0.5"
+    memory: "4Gi"
+    cpu: "500m"
   requests:
-    memory: "2GB"
-    cpu: "0.25"
+    memory: "2Gi"
+    cpu: "250m"
 
 livenessProbe:
   enabled: false
@@ -173,10 +173,10 @@ worker:
   replicaCount: 3
   resources:
     limits:
-      memory: "12GB"
+      memory: "12Gi"
       cpu: "6"
     requests:
-      memory: "6GB"
+      memory: "6Gi"
       cpu: "3"
   podSecurityContext:
     runAsUser: 1001

--- a/ops/staging-deploy.tmpl.yaml
+++ b/ops/staging-deploy.tmpl.yaml
@@ -1,12 +1,12 @@
 replicaCount: 2
 
 resources:
-  requests:
-    memory: "1Gi"
-    cpu: "250m"
   limits:
     memory: "2Gi"
     cpu: "1000m"
+  requests:
+    memory: "1Gi"
+    cpu: "250m"
 
 livenessProbe:
   enabled: false
@@ -182,12 +182,12 @@ extraEnvVars: &envVars
 worker:
   replicaCount: 1
   resources:
-    requests:
-      memory: "1Gi"
-      cpu: "250m"
     limits:
       memory: "2Gi"
       cpu: "1000m"
+    requests:
+      memory: "1Gi"
+      cpu: "250m"
   podSecurityContext:
     runAsUser: 1001
     runAsGroup: 101


### PR DESCRIPTION
Deploy was failing for the wrong regex expression values for the deployment cpu limits and request values, this pr converts those values to milliCPU to accommodate the deployment regex expression. And changes GB to Gi to standardize.

This is the error message in the failed deployment logs that lead me to the issue.
```yaml
Limits: unmarshalerDecoder: quantities must match the regular expression '^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$', error found in #10 byte of ...|ory":"4GB"},"request|..., bigger context ...|,"resources":{"limits":{"cpu":"0.6","memory":"4GB"},"requests":{"cpu":"0.3","memory":"2GB"}},"securi|...
```