### PR TITLE
🎁 Copy over reindex tasks

### DIFF
--- a/app/jobs/file_set_index_job.rb
+++ b/app/jobs/file_set_index_job.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class FileSetIndexJob < Hyrax::ApplicationJob
+  def perform(file_set)
+    file_set&.update_index
+  end
+end

--- a/app/jobs/reindex_collections_job.rb
+++ b/app/jobs/reindex_collections_job.rb
@@ -1,10 +1,14 @@
 # frozen_string_literal: true
 
 class ReindexCollectionsJob < ApplicationJob
-  def perform
-    Collection.find_each do |collection|
-      @collection.try(:reindex_extent=, Hyrax::Adapters::NestingIndexAdapter::LIMITED_REINDEX)
-      collection.update_index
+  def perform(collection_id: nil)
+    if collection_id
+      Collection.find(collection_id).update_index
+    else
+      Collection.find_each do |collection|
+        collection.reindex_extent = Hyrax::Adapters::NestingIndexAdapter::LIMITED_REINDEX
+        collection.update_index
+      end
     end
   end
 end

--- a/app/jobs/reindex_works_job.rb
+++ b/app/jobs/reindex_works_job.rb
@@ -1,9 +1,13 @@
 # frozen_string_literal: true
 
 class ReindexWorksJob < ApplicationJob
-  def perform
-    Hyrax.config.registered_curation_concern_types.each do |work_type|
-      work_type.constantize.find_each(&:update_index)
+  def perform(work = nil)
+    if work.present?
+      work.update_index
+    else
+      Hyrax.config.registered_curation_concern_types.each do |work_type|
+        work_type.constantize.find_each(&:update_index)
+      end
     end
   end
 end

--- a/lib/tasks/index.rake
+++ b/lib/tasks/index.rake
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'ruby-progressbar'
+
+namespace :hyku do
+  desc "reindex just the works in the background"
+  task reindex_works: :environment do
+    Account.find_each do |account|
+      puts "=============== #{account.name}============"
+      next if account.name == "search"
+      switch!(account)
+      begin
+        Site.instance.available_works.each do |work_type|
+          title = "~ #{account.name} - #{work_type}"
+          klass = work_type.constantize
+          progressbar = ProgressBar.create(total: klass.count, title: title, format: "%t %c of %C %a %B %p%%")
+          klass.find_each do |w|
+            ReindexWorksJob.perform_later(w)
+            progressbar.increment
+          end
+        end
+      rescue StandardError => e
+        puts "(#{e.message})"
+      end
+    end
+  end
+
+  desc "reindex just the collections in the background"
+  task reindex_collections: :environment do
+    Account.find_each do |account|
+      puts "=============== #{account.name}============"
+      next if account.name == "search"
+      switch!(account)
+      title = "~ #{account.name}"
+      progressbar = ProgressBar.create(total: Collection.count, title: title, format: "%t %c of %C %a %B %p%%")
+      begin
+        Collection.find_each do |collection|
+          ReindexCollectionsJob.perform_later(collection_id: collection.id)
+          progressbar.increment
+        end
+      rescue StandardError => e
+        puts "(#{e.message})"
+      end
+    end
+  end
+
+  desc "reindex just the filesets in the background"
+  task reindex_filesets: :environment do
+    Account.find_each do |account|
+      puts "=============== #{account.name}============"
+      next if account.name == "search"
+      switch!(account)
+      title = "~ #{account.name}"
+      progressbar = ProgressBar.create(total: FileSet.count, title: title, format: "%t %c of %C %a %B %p%%")
+      begin
+        FileSet.find_each do |file_set|
+          FileSetIndexJob.perform_later(file_set)
+          progressbar.increment
+        end
+      rescue StandardError => e
+        puts "(#{e.message})"
+      end
+    end
+  end
+end


### PR DESCRIPTION
Copying over these tasks will make it easier for us to reindex staging/prod

Refs:

- https://github.com/scientist-softserv/louisville-hyku/blob/main/lib/tasks/index.rake

# Expected Behavior Before Changes

We had to manually reindex via rancher console

# Expected Behavior After Changes

we can call on a reindex tasks that will create reindex jobs. 

```
rake hyku:reindex_collections  # reindex just the collections in the background
rake hyku:reindex_filesets     # reindex just the filesets in the background
rake hyku:reindex_works        # reindex just the works in the background
```
