### PR TITLE
I442 transcripts on manifests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -98,6 +98,7 @@ gem 'hyrax', git: 'https://github.com/samvera/hyrax.git', branch: '3.x-stable'
 gem 'redlock', '~>1.2.2'
 
 gem 'hyrax-iiif_av', git: 'https://github.com/samvera-labs/hyrax-iiif_av.git', branch: 'utk-hyku-with-hyrax-3'
+gem 'iiif_manifest', git: 'https://github.com/samvera/iiif_manifest.git', ref: 'e5d8a2d'
 gem 'iiif_print', git: 'https://github.com/scientist-softserv/iiif_print.git', ref: '8fdf56e'
 
 gem 'bolognese', '>= 1.9.10'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,12 +10,13 @@ GIT
 
 GIT
   remote: https://github.com/samvera-labs/bulkrax.git
-  revision: 09e8d2f05aa0822f544a8545cf263013ffd52d9a
+  revision: ae05be9a0dd7fa95d260069c5274c816e24293bd
   branch: main
   specs:
-    bulkrax (5.1.0)
+    bulkrax (5.2.1)
       bagit (~> 0.4)
       coderay
+      dry-monads (~> 1.4.0)
       iso8601 (~> 0.9.0)
       kaminari
       language_list (~> 1.2, >= 1.2.1)
@@ -112,6 +113,14 @@ GIT
       signet
       tinymce-rails (~> 5.10)
       valkyrie (~> 2, >= 2.1.1)
+
+GIT
+  remote: https://github.com/samvera/iiif_manifest.git
+  revision: e5d8a2d3b775665e59dc123bd461cac5ac7c9cce
+  ref: e5d8a2d
+  specs:
+    iiif_manifest (1.3.1)
+      activesupport (>= 4)
 
 GIT
   remote: https://github.com/scientist-softserv/iiif_print.git
@@ -631,8 +640,6 @@ GEM
       activesupport (>= 3.2.18)
       faraday (>= 0.9)
       json
-    iiif_manifest (1.3.1)
-      activesupport (>= 4)
     is_it_working (1.1.0)
     iso-639 (0.3.5)
     iso8601 (0.9.1)
@@ -1319,6 +1326,7 @@ DEPENDENCIES
   hyrax-iiif_av!
   i18n-debug
   i18n-tasks
+  iiif_manifest!
   iiif_print!
   is_it_working
   jbuilder (~> 2.5)

--- a/app/presenters/hyrax/iiif_manifest_presenter_decorator.rb
+++ b/app/presenters/hyrax/iiif_manifest_presenter_decorator.rb
@@ -52,6 +52,57 @@ module Hyrax
       def file_set?
         super && (image? || audio? || video?) && intermediate_file?
       end
+
+      # OVERRIDE Hyrax 3.5.0 to use #supplementing_content for IIIF Manifest v1.3.1
+      def supplementing_content
+        @supplementing_content ||= begin
+          return [] unless media_and_transcript?
+
+          attachments = transcript_attachments
+          attachments.map do |attachment|
+            create_supplementing_content(attachment)
+          end
+        end
+      end
+
+      private
+
+        TRANSCRIPT_RDF_TYPE = "http://pcdm.org/use#Transcript"
+
+        def media_and_transcript?
+          (audio? || video?) && transcript_attachments.present?
+        end
+
+        def transcript_attachments
+          parent = ::FileSet.find(id).parent.member_of.first
+          return [] unless parent
+
+          parent.members.select { |member| member.rdf_type == [TRANSCRIPT_RDF_TYPE] }
+        end
+
+        def create_supplementing_content(attachment)
+          hash = get_file_set_ids_and_languages(attachment)
+          captions_url = get_captions_url(hash[:file_set_id])
+          IIIFManifest::V3::SupplementingContent.new(captions_url,
+                                                     type: 'text',
+                                                     format: 'text/vtt',
+                                                     label: hash[:title],
+                                                     language: hash[:language].first || 'en')
+        end
+
+        def get_file_set_ids_and_languages(attachment)
+          {
+            file_set_id: attachment.file_sets.first.id,
+            title: attachment.title.first,
+            language: attachment.file_language
+          }
+        end
+
+        def get_captions_url(file_set_id)
+          captions_url = Hyrax::Engine.routes.url_helpers.download_url(file_set_id, host: hostname)
+          ssl_configured = Site.account.ssl_configured
+          ssl_configured ? captions_url.sub!(/\Ahttp:/, 'https:') : captions_url
+        end
     end
 
     private

--- a/spec/presenters/hyrax/iiif_manifest_presenter_spec.rb
+++ b/spec/presenters/hyrax/iiif_manifest_presenter_spec.rb
@@ -52,32 +52,9 @@ RSpec.describe Hyrax::IiifManifestPresenter, skip: "TODO: address in #414 - many
     let(:solr_doc) { SolrDocument.new(file_set.to_solr) }
     let(:file_set) { create(:file_set, :image) }
 
-    describe '#display_content' do
-      it 'gives a IIIFManifest::DisplayImage' do
-        expect(presenter.display_content.to_json)
-          .to include 'fcr:versions%2Fversion1/full'
-      end
-
-      context 'with non-image file_set' do
-        let(:file_set) { create(:file_set) }
-
-        it 'returns nil' do
-          expect(presenter.display_content).to be_nil
-        end
-      end
-
-      context 'when no original file is indexed' do
-        let(:solr_doc) do
-          index_hash = file_set.to_solr
-          index_hash.delete('original_file_id_ssi')
-
-          SolrDocument.new(index_hash)
-        end
-
-        it 'can still resolve the image' do
-          expect(presenter.display_content.to_json)
-            .to include 'fcr:versions%2Fversion1/full'
-        end
+    describe '#supplementing_content' do
+      xit 'returns a IIIFManifest::V3::SupplementingContent object' do
+        # TODO: test this method once this spec is fixed
       end
     end
   end


### PR DESCRIPTION
# Story

[⬆️ Update IIIF Manifest gem](https://github.com/scientist-softserv/utk-hyku/commit/78687cca49a6858f23c80d11341ab2668dd4b74a) 

This commit will bring the latest commit from the IIIF Manifest gem so
we can utilize the new supplementing content feature.

See:
  - https://github.com/samvera/iiif_manifest/pull/96

---

[🎁 Implement #supplementing_content method](https://github.com/scientist-softserv/utk-hyku/commit/5c040360e176ec06e5597c564f4be2d812fc445c) 

This commit will add the `#supplementing_content` method to the
`Hyrax::IiifManifestPresenter::DisplayImagePresenter` which enables the
IIIF Manifest gem to add the annotations to the manifest.  Also, this
commit will add a TODO test for now since the entire suite is not
passing CI.

Ref:
  - https://github.com/scientist-softserv/utk-hyku/issues/442

# Expected Behavior Before Changes

A/V manifests did not have the `annotations` field.

# Expected Behavior After Changes

A/V manifests now will have the `annotations` field.

# Screenshots / Video

<img width="860" alt="image" src="https://github.com/scientist-softserv/utk-hyku/assets/19597776/724cdf1f-30cf-4892-abee-6677fcbe0dba">
