### PR TITLE
🎁 Automatically add thumbnails to non-pdf files

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,12 +10,13 @@ GIT
 
 GIT
   remote: https://github.com/samvera-labs/bulkrax.git
-  revision: 09e8d2f05aa0822f544a8545cf263013ffd52d9a
+  revision: ae05be9a0dd7fa95d260069c5274c816e24293bd
   branch: main
   specs:
-    bulkrax (5.1.0)
+    bulkrax (5.2.1)
       bagit (~> 0.4)
       coderay
+      dry-monads (~> 1.4.0)
       iso8601 (~> 0.9.0)
       kaminari
       language_list (~> 1.2, >= 1.2.1)

--- a/app/jobs/bulkrax/create_relationships_job_decorator.rb
+++ b/app/jobs/bulkrax/create_relationships_job_decorator.rb
@@ -2,26 +2,20 @@
 
 # OVERRIDE IIIF Print v1.0.0 to call SetDefaultParentThumbnailJob
 
-module IiifPrint
+module Bulkrax
   module Jobs
     module CreateRelationshipsJobDecorator
-      def add_to_work(child_record:, parent_record:)
+      def add_to_work(child_record, parent_record)
         super
         set_default_parent_thumbnail(child_record, parent_record) if child_record&.intermediate_file?
       end
 
       def set_default_parent_thumbnail(child_record, parent_record)
-        return unless first_page?(child_record.title.first)
-
         ::SetDefaultParentThumbnailJob.set(wait: 5.minutes)
                                       .perform_later(child_work: child_record, parent_work: parent_record)
-      end
-
-      def first_page?(title)
-        title.match(/Page\s0*1\Z/)
       end
     end
   end
 end
 
-IiifPrint::Jobs::CreateRelationshipsJob.prepend(IiifPrint::Jobs::CreateRelationshipsJobDecorator)
+Bulkrax::Jobs::CreateRelationshipsJob.prepend(Bulkrax::Jobs::CreateRelationshipsJobDecorator)

--- a/spec/jobs/bulkrax/create_relationships_job_decorator_spec.rb
+++ b/spec/jobs/bulkrax/create_relationships_job_decorator_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+module Bulkrax
+  module Jobs
+    RSpec.describe CreateRelationshipsJobDecorator, type: :job do
+      let(:job) { CreateRelationshipsJob.new.extend(CreateRelationshipsJobDecorator) }
+      let(:parent_work) { create(:video) }
+      let(:child_work) { create(:attachment_with_one_file) }
+      let(:job_class) { class_double('ActiveJob::Base') }
+
+      before do
+        # A bit of a code smell but I couldn't find a better way around it.
+        # This does require us to know the details of Bulkrax::Jobs::CreateRelationshipsJob#add_to_work.
+        # Without setting @child_members_added, we get a NoMethodError, undefined method `<<' for nil:NilClass
+        # Ref: https://github.com/samvera-labs/bulkrax/blob/ae05be9a0dd7fa95d260069c5274c816e24293bd/app/jobs/bulkrax/create_relationships_job.rb#L171
+        job.instance_variable_set(:@child_members_added, [])
+        allow(SetDefaultParentThumbnailJob).to receive(:set).with(wait: 5.minutes).and_return(job_class)
+      end
+
+      describe '#set_default_parent_thumbnail' do
+        context 'when the child is an intermediate file' do
+          it 'calls SetDefaultParentThumbnailJob' do
+            allow(child_work).to receive(:intermediate_file?).and_return(true)
+
+            expect(job_class).to receive(:perform_later).with(child_work: child_work, parent_work: parent_work)
+            job.add_to_work(child_work, parent_work)
+          end
+        end
+
+        context 'when the child is not an intermediate file' do
+          it 'does not call SetDefaultParentThumbnailJob' do
+            allow(child_work).to receive(:intermediate_file?).and_return(false)
+
+            expect(job_class).not_to receive(:perform_later)
+            job.add_to_work(child_work, parent_work)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Story

[🎁 Automatically add thumbnails to non-pdf files](https://github.com/scientist-softserv/utk-hyku/commit/752f758039355fb8bc06d04492959a7b56441e04) 

This commit hooks into `Bulkrax::Jobs::CreateRelationshipsJob` to
trigger the `SetDefaultParentThumbnailJob` for non-pdf files.  The two
jobs are very similar yet different enough to make DRYing it up a bit
complicated so I opted for creating a separate decorator.

Ref:
  - https://github.com/scientist-softserv/utk-hyku/issues/438

# Expected Behavior Before Changes

Only PDFs that were split would get their parent work thumbnails set automatically.

# Expected Behavior After Changes

All works should get their thumbnails set automatically.

# Screenshots / Video

<img width="649" alt="image" src="https://github.com/scientist-softserv/utk-hyku/assets/19597776/bc3f2692-bc6f-4a65-a6de-3b351d633dbb">
