### PR TITLE
🐛 Revert to IiifPrint branch main

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -99,7 +99,7 @@ gem 'redlock', '~>1.2.2'
 
 gem 'hyrax-iiif_av', git: 'https://github.com/samvera-labs/hyrax-iiif_av.git', branch: 'utk-hyku-with-hyrax-3'
 gem 'iiif_manifest', git: 'https://github.com/samvera/iiif_manifest.git', ref: 'e5d8a2d'
-gem 'iiif_print', git: 'https://github.com/scientist-softserv/iiif_print.git', branch: 'no-rodeo'
+gem 'iiif_print', git: 'https://github.com/scientist-softserv/iiif_print.git', branch: 'main'
 
 gem 'bolognese', '>= 1.9.10'
 gem 'hyrax-doi', git: 'https://github.com/samvera-labs/hyrax-doi.git'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,17 +124,17 @@ GIT
 
 GIT
   remote: https://github.com/scientist-softserv/iiif_print.git
-  revision: 9f20467a6ff1f14872087f1e1dddda0f9fea91fd
-  branch: no-rodeo
+  revision: fe85c47c1ba8ba7fa0aae14104b86f98a8b581e4
+  branch: main
   specs:
     iiif_print (1.0.0)
       blacklight_iiif_search (~> 1.0)
+      derivative-rodeo (~> 0.3)
       dry-monads (~> 1.4.0)
-      hyrax (>= 2.5, < 4.0)
+      hyrax (>= 2.5, < 4)
       nokogiri (>= 1.13.2)
       rails (~> 5.0)
       rdf-vocab (~> 3.0)
-      reform-rails (= 0.2.3)
 
 GIT
   remote: https://github.com/tawan/active-elastic-job.git
@@ -405,6 +405,15 @@ GEM
     declarative-option (0.1.0)
     deprecation (1.1.0)
       activesupport
+    derivative-rodeo (0.4.0)
+      activesupport (>= 5)
+      aws-sdk-s3
+      aws-sdk-sqs
+      httparty
+      marcel
+      mime-types
+      mini_magick
+      nokogiri
     devise (4.8.1)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)


### PR DESCRIPTION
# Story

Ref: https://github.com/scientist-softserv/utk-hyku/issues/454

- Updates IiifPrint to include fixes to Derivative Rodeo refactors and bug fixes
  - https://github.com/scientist-softserv/iiif_print/pull/256
  - https://github.com/scientist-softserv/iiif_print/pull/257

# Expected Behavior Before Changes

IiifPrint job to split PDFs did not get called.

# Expected Behavior After Changes

Gemfile includes DerivativeRodeo.
PDFs split correctly into child works.

# Screenshots / Video

<details>
<summary></summary>

![Screenshot 2023-07-06 at 3 12 08 PM](https://github.com/scientist-softserv/utk-hyku/assets/17851674/cc375bdd-eaff-4967-b03a-a40d56e2a27f)
</details>

# Notes
Move ticket to complete following SoftServe QA.