### PR TITLE
🎁 Add title sort to catalog search

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -16,6 +16,10 @@ class CatalogController < ApplicationController
     'system_modified_dtsi'
   end
 
+  def self.title_field
+    'title_ssi'
+  end
+
   # CatalogController-scope behavior and configuration for BlacklightIiifSearch
   include BlacklightIiifSearch::Controller
 
@@ -378,6 +382,8 @@ class CatalogController < ApplicationController
     # except in the relevancy case).
     # label is key, solr field is value
     config.add_sort_field "score desc, #{uploaded_field} desc", label: "relevance"
+    config.add_sort_field "#{title_field} desc", label: "title \u25BC"
+    config.add_sort_field "#{title_field} asc", label: "title \u25B2"
     config.add_sort_field "#{uploaded_field} desc", label: "date uploaded \u25BC"
     config.add_sort_field "#{uploaded_field} asc", label: "date uploaded \u25B2"
     config.add_sort_field "#{modified_field} desc", label: "date modified \u25BC"

--- a/app/indexers/app_indexer.rb
+++ b/app/indexers/app_indexer.rb
@@ -13,6 +13,7 @@ class AppIndexer < Hyrax::WorkIndexer
   def generate_solr_document
     super.tap do |solr_doc|
       solr_doc["account_cname_tesim"] = Site.instance&.account&.cname
+      solr_doc["title_ssi"] = object.title.first
     end
   end
 end

--- a/app/indexers/app_indexer.rb
+++ b/app/indexers/app_indexer.rb
@@ -13,7 +13,7 @@ class AppIndexer < Hyrax::WorkIndexer
   def generate_solr_document
     super.tap do |solr_doc|
       solr_doc["account_cname_tesim"] = Site.instance&.account&.cname
-      solr_doc["title_ssi"] = object.title.first
+      solr_doc[CatalogController.title_field] = object.title.first
     end
   end
 end

--- a/app/indexers/collection_indexer.rb
+++ b/app/indexers/collection_indexer.rb
@@ -10,6 +10,7 @@ class CollectionIndexer < Hyrax::CollectionIndexer
     super.tap do |solr_doc|
       solr_doc["bulkrax_identifier_sim"] = object.bulkrax_identifier
       solr_doc["account_cname_tesim"] = Site.instance&.account&.cname
+      solr_doc["title_ssi"] = object.title.first
     end
   end
 end

--- a/app/indexers/collection_indexer.rb
+++ b/app/indexers/collection_indexer.rb
@@ -10,7 +10,7 @@ class CollectionIndexer < Hyrax::CollectionIndexer
     super.tap do |solr_doc|
       solr_doc["bulkrax_identifier_sim"] = object.bulkrax_identifier
       solr_doc["account_cname_tesim"] = Site.instance&.account&.cname
-      solr_doc["title_ssi"] = object.title.first
+      solr_doc[CatalogController.title_field] = object.title.first
     end
   end
 end


### PR DESCRIPTION
This commit will add a title sort (both descending and ascending) to the catalog search results.

Ref:
  - https://github.com/scientist-softserv/utk-hyku/issues/420

# Expected Behavior Before Changes

Users were only able to sort by relevance and date.

# Expected Behavior After Changes

Users should now also have the ability to sort the catalog search results by title, both descending and ascending.

# Screenshots / Video

<img width="693" alt="image" src="https://github.com/scientist-softserv/utk-hyku/assets/19597776/40465031-c837-40e1-8e03-78f8adb2dea9">

# Note

⚠️ THIS REQUIRES A REINDEX OF WORKS ⚠️