### PR TITLE
🎁 Hide empty collection metadata

### DIFF
--- a/app/presenters/hyrax/collection_presenter.rb
+++ b/app/presenters/hyrax/collection_presenter.rb
@@ -47,6 +47,15 @@ Hyrax::CollectionPresenter.class_eval do
     end
   end
 
+  # override to hide empty fields
+  def terms_with_values
+    self.class.terms.select do |t|
+      value = send(t).try(:first)
+      # total_items is always displayed
+      t == :total_items || value.present?
+    end
+  end
+
   # override banner_file in hyrax to include all banner information rather than just relative_path
   def banner_file
     @banner_file ||= begin


### PR DESCRIPTION
This commit will bring over two partials from Hyrax so that we can hide empty metadata fields in the collection show page and the dashboard. The reason why they show in the first place is because Bulkrax brings them in as arrays with empty strings.

Ref:
  - https://github.com/scientist-softserv/utk-hyku/issues/235

# Expected Behavior Before Changes

Empty metadata fields is showing up in the collection's metadata

# Expected Behavior After Changes

There should be no more empty metadata fields.

# Screenshots / Video

<details><summary>Before</summary>

![image](https://github.com/scientist-softserv/utk-hyku/assets/19597776/72bbb7ab-aa6e-4894-be07-c589ba2b03fd)

![image](https://github.com/scientist-softserv/utk-hyku/assets/19597776/a8002835-e4a7-494f-80e8-289c332db8fc)

</details>

<details><summary>After</summary>

![image](https://github.com/scientist-softserv/utk-hyku/assets/19597776/1d757242-570e-4e13-9bf9-304883619974)

![image](https://github.com/scientist-softserv/utk-hyku/assets/19597776/0ff9f8c9-8b78-4102-bb3b-7a7c3bc2acfc)

</details>
