### PR TITLE
I460 i423 catalog and iiif search

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/samvera-labs/allinson_flex.git
-  revision: f73ca7f4834c1f96617b3b960b8e8a277c730249
+  revision: e98815f6178cc17fab70c189d0fe96a618384a7a
   specs:
     allinson_flex (0.1.0)
       json_schemer
@@ -124,12 +124,12 @@ GIT
 
 GIT
   remote: https://github.com/scientist-softserv/iiif_print.git
-  revision: fe85c47c1ba8ba7fa0aae14104b86f98a8b581e4
+  revision: 0c3edc4f9855e2066a4622970a7d401648b5eb2a
   branch: main
   specs:
     iiif_print (1.0.0)
       blacklight_iiif_search (~> 1.0)
-      derivative-rodeo (~> 0.3)
+      derivative-rodeo (~> 0.4)
       dry-monads (~> 1.4.0)
       hyrax (>= 2.5, < 4)
       nokogiri (>= 1.13.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,7 +124,7 @@ GIT
 
 GIT
   remote: https://github.com/scientist-softserv/iiif_print.git
-  revision: 0c3edc4f9855e2066a4622970a7d401648b5eb2a
+  revision: 7b82aa323db891f5f8e362e13bf3f14b4fe9e0dc
   branch: main
   specs:
     iiif_print (1.0.0)
@@ -405,7 +405,7 @@ GEM
     declarative-option (0.1.0)
     deprecation (1.1.0)
       activesupport
-    derivative-rodeo (0.4.0)
+    derivative-rodeo (0.4.2)
       activesupport (>= 5)
       aws-sdk-s3
       aws-sdk-sqs

--- a/app/models/iiif_search_builder.rb
+++ b/app/models/iiif_search_builder.rb
@@ -3,8 +3,9 @@
 # SearchBuilder for full-text searches with highlighting and snippets
 class IiifSearchBuilder < Blacklight::SearchBuilder
   include Blacklight::Solr::SearchBuilderBehavior
+  include IiifPrint::AllinsonFlexFields
 
-  self.default_processor_chain += [:ocr_search_params]
+  self.default_processor_chain += %i[ocr_search_params include_allinson_flex_fields]
 
   # set params for ocr field searching
   def ocr_search_params(solr_parameters = {})

--- a/app/views/catalog/_index_header_list_default.html.erb
+++ b/app/views/catalog/_index_header_list_default.html.erb
@@ -1,12 +1,21 @@
 <%# OVERRIDE Hyrax 3.4.0 to support shared search %>
 <%# OVERRIDE Hyrax 3.4.2 add classes for custom styling %>
+<%# OVERRIDE Hyrax 3.5.0 to bring in parent_query for UV auto searching %>
 
 <% model = document.hydra_model %>
 <div class="search-results-title-row">
-    <% if model == Hyrax::PcdmCollection || model < Hyrax::PcdmCollection %>
-        <h4 class="search-result-title collection"><%= link_to document.title_or_label, generate_work_url(document, request) %></h4>
-        <%= Hyrax::CollectionPresenter.new(document, current_ability).collection_type_badge %>
-    <% else %>
-        <h4 class="search-result-title work"><%= link_to document.title_or_label, generate_work_url(document, request) %></h4>
-    <% end %>
+  <% if model == Hyrax::PcdmCollection || model < Hyrax::PcdmCollection %>
+    <h4 class="search-result-title collection"><%= link_to document.title_or_label, generate_work_url(document, request) %></h4>
+    <%= Hyrax::CollectionPresenter.new(document, current_ability).collection_type_badge %>
+  <% else %>
+    <h3 class="search-result-title work">
+      <% if params['q'].present? && document.any_highlighting? %>
+        <%= link_to document.title_or_label, [document, { parent_query: params['q'] }] %>
+      <% elsif params['q'].present? %>
+        <%= link_to document.title_or_label, [document, { query: params['q'] }] %>
+      <% else %>
+        <%= link_to document.title_or_label, document %>
+      <% end %>
+    </h3>
+  <% end %>
 </div>

--- a/config/uv/uv.html
+++ b/config/uv/uv.html
@@ -19,20 +19,20 @@
             }
         </style>
         <script type="text/javascript">
-        window.addEventListener('uvLoaded', function(e) { 
+        window.addEventListener('uvLoaded', function(e) {
                 urlDataProvider = new UV.URLDataProvider(true);
                 var formattedLocales;
                 var locales = urlDataProvider.get('locales', '');
-    
+
                 if (locales) {
                     var names = locales.split(',');
                     formattedLocales = [];
-    
+
                     for (var i in names) {
                         var nameparts = String(names[i]).split(':');
                         formattedLocales[i] = {name: nameparts[0], label: nameparts[1]};
                     }
-                    
+
                 } else {
                     formattedLocales = [
                         {
@@ -40,7 +40,7 @@
                         }
                     ]
                 }
-    
+
                 uv = createUV('#uv', {
                     root: '.',
                     iiifResourceUri: urlDataProvider.get('manifest'),
@@ -53,34 +53,35 @@
                     rotation: Number(urlDataProvider.get('r', 0)),
                     xywh: urlDataProvider.get('xywh', ''),
                     embedded: true,
+                    highlight: urlDataProvider.get('q'),
                     locales: formattedLocales
                 }, urlDataProvider);
             }, false);
         </script>
-    </head>    
+    </head>
     <body>
-    
+
         <div id="uv" class="uv"></div>
-    
+
         <script>
             $(function() {
-        
+
                 var $UV = $('#uv');
-        
+
                 function resize() {
                     var windowWidth = window.innerWidth;
                     var windowHeight = window.innerHeight;
                     $UV.width(windowWidth);
                     $UV.height(windowHeight);
                 }
-        
+
                 $(window).on('resize' ,function() {
                     resize();
                 });
-                
+
                 resize();
             });
-            
+
         </script>
         <script type="text/javascript" src="uv.js"></script>
     </body>


### PR DESCRIPTION
# Story

[⬆️ Update IIIF Print and AllinsonFlex](https://github.com/scientist-softserv/utk-hyku/pull/467/commits/78589c2c8d61588b8726df6124919c2b115af6ef) 

This commit will update both IIIF Print and AllinsonFlex to bring in
changes that will enable catalog and IIIF searches to work with
AllinsonFlex fields.

Ref:
  - https://github.com/scientist-softserv/utk-hyku/issues/460
  - https://github.com/scientist-softserv/utk-hyku/issues/423

---

[🎁 Add auto searching from catalog to UV](https://github.com/scientist-softserv/utk-hyku/pull/467/commits/a537213c31fddc1300a95f6f352760ed3ef3c6ce) 

This commit will enable the UV to automatically search the term that was
used in the catalog search.  This was originally supposed to have been
working because it is a feature of IIIF Print.


# Expected Behavior Before Changes

AllinsonFlex fields were not searchable through the catalog nor the UV.

# Expected Behavior After Changes

AllinsonFlex fields are now searchable through the catalog and UV.  Also, when you click on a search result, the UV remembers what you searched for and automatically carries that through to the show page and searches the UV for those terms.

# Screenshots / Video

<details>
<summary>Before (UV search)</summary>

<img width="1159" alt="image" src="https://github.com/scientist-softserv/utk-hyku/assets/19597776/b6b45926-8f1b-49cd-bf0d-70994a75f285">

</details>

<details>
<summary>After (UV search)</summary>

<img width="1172" alt="image" src="https://github.com/scientist-softserv/utk-hyku/assets/19597776/09af6aba-c818-48cc-89e7-f2dcc569c382">

</details>

<details>
<summary>Before (catalog search)</summary>

<img width="987" alt="image" src="https://github.com/scientist-softserv/utk-hyku/assets/19597776/8da069ee-36eb-4c21-b11a-301db5047b87">

</details>

<details>
<summary>After (catalog search)</summary>

<img width="928" alt="image" src="https://github.com/scientist-softserv/utk-hyku/assets/19597776/61f7dc79-f491-4ecc-a4ab-da1b345b8c95">

</details>
