### PR TITLE
🎁 Bring back edit button on work show page

### DIFF
--- a/app/views/themes/dc_show/hyrax/base/show.html.erb
+++ b/app/views/themes/dc_show/hyrax/base/show.html.erb
@@ -11,9 +11,7 @@
       <div class="col-sm-12">
         <%= render 'work_type', presenter: @presenter %>
       </div>
-      <%# OVERRIDE: Hyrax v3.4.2 - show_actions being commented out in case they are needed in the future. %>
-      <%#= render 'show_actions', presenter: @presenter %>
-      <%# OVERRIDE: Hyrax v3.4.2 - add classes %>
+      <%= render 'show_actions', presenter: @presenter %>
       <div class="works-panel uv-panel">
         <div class="panel-body">
           <div class="row">


### PR DESCRIPTION
[🎁 Bring back edit button on work show page](https://github.com/scientist-softserv/utk-hyku/commit/b0319ee0fb185840a9e157616a1bf499b299c182) 

This commit will bring back the edit button that was previously hidden
because the wire frames did not display it.

Ref:
  - https://github.com/scientist-softserv/utk-hyku/issues/468

# Story

# Expected Behavior Before Changes

The work show page did not have the edit button making it difficult to edit the work.

# Expected Behavior After Changes

The work show page now has the edit button and other actions back.

# Screenshots / Video

<details>
<summary>Before</summary>

<img width="1165" alt="image" src="https://github.com/scientist-softserv/utk-hyku/assets/19597776/7a9e02cb-d943-47ea-9e34-79a949cf860f">

</details>

<details>
<summary>After</summary>

<img width="1157" alt="image" src="https://github.com/scientist-softserv/utk-hyku/assets/19597776/71c6445f-feae-44cd-a942-5ec2c8c38b3b">

</details>
