### PR TITLE
:broom: disable the feature button and the featured works feat flipper

### DIFF
--- a/app/controllers/hyrax/homepage_controller.rb
+++ b/app/controllers/hyrax/homepage_controller.rb
@@ -36,7 +36,7 @@ module Hyrax
     # OVERRIDE: Hyrax v3.4.2 - For dc_repository add @collections_list
 
     def index
-      @presenter = presenter_class.new(current_ability, collections)
+      @presenter = presenter_class.new(current_ability, collections, current_account)
       @featured_researcher = ContentBlock.for(:researcher)
       @marketing_text = ContentBlock.for(:marketing)
       @home_text = ContentBlock.for(:home_text)

--- a/app/helpers/accounts_helper.rb
+++ b/app/helpers/accounts_helper.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 module AccountsHelper
+  TENANTS_WITH_NO_WORK_FEATURES = ['dc'].freeze
 end

--- a/app/presenters/hyrax/homepage_presenter.rb
+++ b/app/presenters/hyrax/homepage_presenter.rb
@@ -56,7 +56,8 @@ module Hyrax
 
     # changed to add feature flag for featured work
     def display_featured_works?
-      Flipflop.show_featured_works?
+      # Flipflop.show_featured_works?
+      false
     end
 
     # changed to add feature flag for recently uploaded

--- a/app/presenters/hyrax/homepage_presenter.rb
+++ b/app/presenters/hyrax/homepage_presenter.rb
@@ -11,9 +11,10 @@ module Hyrax
     self.create_work_presenter_class = Hyrax::SelectTypeListPresenter
     attr_reader :current_ability, :collections
 
-    def initialize(current_ability, collections)
+    def initialize(current_ability, collections, current_account = nil)
       @current_ability = current_ability
       @collections = collections
+      @current_account = current_account
     end
 
     # OVERRIDE: Hyrax v3.4.0 to removed: @return [Boolean] If the
@@ -56,8 +57,9 @@ module Hyrax
 
     # changed to add feature flag for featured work
     def display_featured_works?
-      # Flipflop.show_featured_works?
-      false
+      return false if @current_account.name == 'dc'
+
+      Flipflop.show_featured_works?
     end
 
     # changed to add feature flag for recently uploaded

--- a/app/presenters/hyrax/homepage_presenter.rb
+++ b/app/presenters/hyrax/homepage_presenter.rb
@@ -57,7 +57,7 @@ module Hyrax
 
     # changed to add feature flag for featured work
     def display_featured_works?
-      return false if AccountsHelper::TENANTS_WITH_NO_WORK_FEATURES.include?(@current_account.name) 
+      return false if AccountsHelper::TENANTS_WITH_NO_WORK_FEATURES.include?(@current_account.name)
 
       Flipflop.show_featured_works?
     end

--- a/app/presenters/hyrax/homepage_presenter.rb
+++ b/app/presenters/hyrax/homepage_presenter.rb
@@ -57,7 +57,7 @@ module Hyrax
 
     # changed to add feature flag for featured work
     def display_featured_works?
-      return false if @current_account.name == 'dc'
+      return false if AccountsHelper::TENANTS_WITH_NO_WORK_FEATURES.include?(@current_account.name) 
 
       Flipflop.show_featured_works?
     end

--- a/app/views/hyrax/admin/features/index.html.erb
+++ b/app/views/hyrax/admin/features/index.html.erb
@@ -29,7 +29,6 @@
                 </tr>
               <% end -%>
               <% #OVERRIDE HYRAX 3.5.0 to skip show_featured_works per denylist: TENANTS_WITH_NO_WORK_FEATURES %>
-              <% raise '' %>
               <% modified_features = features.reject { |item| item.instance_variable_get(:@key) == :show_featured_works && AccountsHelper::TENANTS_WITH_NO_WORK_FEATURES.include?(current_account.name) } %>
               <% modified_features.each do |feature| %>
               <tr data-feature="<%= feature.name.dasherize.parameterize %>">

--- a/app/views/hyrax/admin/features/index.html.erb
+++ b/app/views/hyrax/admin/features/index.html.erb
@@ -28,8 +28,9 @@
                   </td>
                 </tr>
               <% end -%>
-              <% #OVERRIDE HYRAX 3.5.0 to skip show_featured_works for the dc tenant %>
-              <% modified_features = features.reject { |item| item.instance_variable_get(:@key) == :show_featured_works && current_account.name == 'dc' } %>
+              <% #OVERRIDE HYRAX 3.5.0 to skip show_featured_works per denylist: TENANTS_WITH_NO_WORK_FEATURES %>
+              <% raise '' %>
+              <% modified_features = features.reject { |item| item.instance_variable_get(:@key) == :show_featured_works && AccountsHelper::TENANTS_WITH_NO_WORK_FEATURES.include?(current_account.name) } %>
               <% modified_features.each do |feature| %>
               <tr data-feature="<%= feature.name.dasherize.parameterize %>">
                 <td class="status">

--- a/app/views/hyrax/admin/features/index.html.erb
+++ b/app/views/hyrax/admin/features/index.html.erb
@@ -1,0 +1,70 @@
+<% #OVERRIDE HYRAX 3.5.0 to skip show_featured_works for the dc tenant %>
+<% provide :page_header do %>
+  <h1><span class="fa fa-wrench" aria-hidden="true"></span> <%= t('.header') %></h1>
+<% end %>
+<div class="flip row">
+  <div class="col-md-12">
+    <div class="card">
+      <div class="card-body">
+        <div class="table-responsive">
+          <table class="table table-striped">
+            <thead>
+              <tr>
+                <th></th>
+                <th class="name"><%= t('.feature') %></th>
+                <th class="description"><%= t('.description') %></th>
+                <th class="action"><%= t('.action') %></th>
+              </tr>
+            </thead>
+            <tbody>
+            <% @feature_set.grouped_features.each do |group, features| -%>
+              <% if @feature_set.grouped? -%>
+                <tr class="group">
+                  <td></td>
+                  <td class="name" colspan="<%= 2 + @feature_set.strategies.size -%>">
+                    <h2>
+                      <%= t(group ? group.name : :default, scope: [:flipflop, :groups], default: group ? group.title : nil) -%>
+                    </h2>
+                  </td>
+                </tr>
+              <% end -%>
+              <% #OVERRIDE HYRAX 3.5.0 to skip show_featured_works for the dc tenant %>
+              <% modified_features = features.reject { |item| item.instance_variable_get(:@key) == :show_featured_works && current_account.name == 'dc' } %>
+              <% modified_features.each do |feature| %>
+              <tr data-feature="<%= feature.name.dasherize.parameterize %>">
+                <td class="status">
+                  <span class="badge badge-<%= @feature_set.status(feature) -%>"><%= @feature_set.status(feature) -%></span>
+                </td>
+                <td class="name"><%= feature.name.humanize -%></td>
+                <td class="description"><%= feature.description -%></td>
+
+                <% @feature_set.strategies.each do |strategy| -%>
+                  <% next unless strategy.is_a? Flipflop::Strategies::ActiveRecordStrategy %>
+                  <td class="toggle" data-strategy="<%= strategy.name.dasherize.parameterize %>">
+                    <div class="toolbar">
+                      <%= form_tag(hyrax.admin_feature_strategy_path(feature.key, strategy.key), method: :put) do -%>
+                        <div class="btn-group">
+                          <%= submit_tag "on",
+                            type: "submit",
+                            class: Flipflop.enabled?(feature.name.to_sym) ? 'active' : nil,
+                            disabled: !strategy.switchable? -%>
+
+                          <%= submit_tag "off",
+                            type: "submit",
+                            class: Flipflop.enabled?(feature.name.to_sym) ? nil : 'active',
+                            disabled: !strategy.switchable? -%>
+                        </div>
+                      <% end -%>
+                    </div>
+                  </td>
+                <% end -%>
+              </tr>
+              <% end -%>
+            <% end -%>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/hyrax/base/_show_actions.html.erb
+++ b/app/views/hyrax/base/_show_actions.html.erb
@@ -1,0 +1,64 @@
+<%# OVERRIDE Hyrax 3.5.0 to remove feature work button %>
+
+<div class="row show-actions button-row-top-two-column">
+  <div class="col-sm-6">
+    <% if !workflow_restriction?(presenter) %>
+      <% if presenter.show_deposit_for?(collections: @user_collections) %>
+        <input type="checkbox"  style="display:none" name="batch_document_ids[]" id="batch_document_<%= presenter.id %>" value="<%= presenter.id %>" class="batch_document_selector" checked="checked" />
+        <%= button_tag t('hyrax.dashboard.my.action.add_to_collection'),
+                      class: 'btn btn-default submits-batches submits-batches-add',
+                      data: { toggle: "modal", target: "#collection-list-container" } %>
+      <% end %>
+      <%# OVERRIDE begin %>
+      <%# if presenter.work_featurable? %>
+        <%#= link_to t('.feature'), hyrax.featured_work_path(presenter, format: :json),
+            data: { behavior: 'feature' },
+            class: presenter.display_feature_link? ? 'btn btn-default' : 'btn btn-default collapse' %>
+
+        <%#= link_to t('.unfeature'), hyrax.featured_work_path(presenter, format: :json),
+            data: { behavior: 'unfeature' },
+            class: presenter.display_unfeature_link? ? 'btn btn-default' : 'btn btn-default collapse' %>
+      <%# end %>
+      <%# OVERRIDE end %>
+    <% end %>
+    <% if Hyrax.config.analytics? %>
+      <% # turbolinks needs to be turned off or the page will use the cache and the %>
+      <% # analytics graph will not show unless the page is refreshed. %>
+      <%= link_to t('.analytics'), presenter.stats_path, id: 'stats', class: 'btn btn-default', data: { turbolinks: false } %>
+    <% end %>
+  </div>
+
+  <div class="col-sm-6 text-right">
+    <% if presenter.editor? && !workflow_restriction?(presenter) %>
+      <%= link_to t('.edit'), edit_polymorphic_path([main_app, presenter]), class: 'btn btn-default' %>
+      <% if presenter.member_count > 1 %>
+          <%= link_to t("hyrax.file_manager.link_text"), polymorphic_path([main_app, :file_manager, presenter]), class: 'btn btn-default' %>
+      <% end %>
+      <% if presenter.valid_child_concerns.length > 0 %>
+        <div class="btn-group">
+          <button type="button" class="btn btn-default dropdown-toggle" type="button" id="dropdown-menu" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            <%= t('.attach_child') %> <span class="caret"></span></button>
+            <ul class="dropdown-menu">
+              <% presenter.valid_child_concerns.each do |concern| %>
+                <li>
+                  <%= link_to "Attach #{concern.human_readable_type}", polymorphic_path([main_app, :new, :hyrax, :parent, concern.model_name.singular.to_sym], parent_id: presenter.id) %>
+                </li>
+              <% end %>
+            </ul>
+        </div>
+      <% end %>
+      <%= link_to t('.delete'), [main_app, presenter], class: 'btn btn-danger', data: { confirm: t('.confirm_delete', work_type: presenter.human_readable_type) }, method: :delete %>
+    <% end %>
+  </div>
+</div>
+
+<!-- COinS hook for Zotero -->
+  <span class="Z3988" title="<%= export_as_openurl_ctx_kev(presenter) %>"></span>
+<!-- Render Modals -->
+  <%= render 'hyrax/dashboard/collections/form_for_select_collection', user_collections: @user_collections %> 
+
+
+
+
+
+

--- a/app/views/hyrax/base/_show_actions.html.erb
+++ b/app/views/hyrax/base/_show_actions.html.erb
@@ -10,7 +10,7 @@
                       data: { toggle: "modal", target: "#collection-list-container" } %>
       <% end %>
       <%# OVERRIDE begin %>
-      <% if presenter.work_featurable? && current_account.name != 'dc' %>
+      <% if presenter.work_featurable? && AccountsHelper::TENANTS_WITH_NO_WORK_FEATURES.include?(@current_account.name) %>
         <%= link_to t('.feature'), hyrax.featured_work_path(presenter, format: :json),
             data: { behavior: 'feature' },
             class: presenter.display_feature_link? ? 'btn btn-default' : 'btn btn-default collapse' %>

--- a/app/views/hyrax/base/_show_actions.html.erb
+++ b/app/views/hyrax/base/_show_actions.html.erb
@@ -10,15 +10,16 @@
                       data: { toggle: "modal", target: "#collection-list-container" } %>
       <% end %>
       <%# OVERRIDE begin %>
-      <%# if presenter.work_featurable? %>
-        <%#= link_to t('.feature'), hyrax.featured_work_path(presenter, format: :json),
+      <% if presenter.work_featurable? && current_account.name != 'dc' %>
+        <%= link_to t('.feature'), hyrax.featured_work_path(presenter, format: :json),
             data: { behavior: 'feature' },
             class: presenter.display_feature_link? ? 'btn btn-default' : 'btn btn-default collapse' %>
-
-        <%#= link_to t('.unfeature'), hyrax.featured_work_path(presenter, format: :json),
+        <%= link_to t('.unfeature'), hyrax.featured_work_path(presenter, format: :json),
             data: { behavior: 'unfeature' },
             class: presenter.display_unfeature_link? ? 'btn btn-default' : 'btn btn-default collapse' %>
-      <%# end %>
+      <% end %>
+
+
       <%# OVERRIDE end %>
     <% end %>
     <% if Hyrax.config.analytics? %>

--- a/config/features.rb
+++ b/config/features.rb
@@ -9,9 +9,12 @@ Flipflop.configure do
           default: true,
           description: "Shows the 'Share Your Work' button on the homepage."
 
-  feature :show_featured_works,
-          default: true,
-          description: "Shows the Featured Works tab on the homepage."
+  # Commenting this out means all tenants won't get this the show_featured_works flipper
+  # TODO: We should find a way to make this tenant specific
+  # ref: https://github.com/scientist-softserv/utk-hyku/issues/47
+  #   feature :show_featured_works,
+  #           default: true,
+  #           description: "Shows the Featured Works tab on the homepage."
 
   feature :show_recently_uploaded,
           default: true,

--- a/config/features.rb
+++ b/config/features.rb
@@ -9,12 +9,9 @@ Flipflop.configure do
           default: true,
           description: "Shows the 'Share Your Work' button on the homepage."
 
-  # Commenting this out means all tenants won't get this the show_featured_works flipper
-  # TODO: We should find a way to make this tenant specific
-  # ref: https://github.com/scientist-softserv/utk-hyku/issues/47
-  #   feature :show_featured_works,
-  #           default: true,
-  #           description: "Shows the Featured Works tab on the homepage."
+  feature :show_featured_works,
+          default: false,
+          description: "Shows the Featured Works tab on the homepage."
 
   feature :show_recently_uploaded,
           default: true,

--- a/config/features.rb
+++ b/config/features.rb
@@ -10,7 +10,7 @@ Flipflop.configure do
           description: "Shows the 'Share Your Work' button on the homepage."
 
   feature :show_featured_works,
-          default: false,
+          default: true,
           description: "Shows the Featured Works tab on the homepage."
 
   feature :show_recently_uploaded,

--- a/spec/controllers/hyrax/homepage_controller_spec.rb
+++ b/spec/controllers/hyrax/homepage_controller_spec.rb
@@ -110,7 +110,8 @@ RSpec.describe Hyrax::HomepageController, type: :controller, clean: true do
 
       it "initializes the presenter with ability and a list of collections" do
         expect(Hyrax::HomepagePresenter).to receive(:new).with(Ability,
-                                                               [collection])
+                                                               [collection],
+                                                               Account)
                                                          .and_return(presenter)
         get :index
         expect(response).to be_success


### PR DESCRIPTION
The ability to use featured works has been removed in previous work, per client request for the DC tenant. Because of this it's misleading and confusing for the user to have the ability to toggle featured works on and off. It's also misleading to have a feature/unfeature buton. 

This PR addresses the clean up work to reduce such confusion for the DC tenant. All other tenants should still behave like the hyku default (w the ability to set featured works)

- Issue https://github.com/scientist-softserv/utk-hyku/issues/472


# Expected Behavior Before Changes (dc tenant)

<img width="1341" alt="image" src="https://github.com/scientist-softserv/utk-hyku/assets/10081604/774a4254-b6c0-4f5f-ac7d-89f017b13675">

![image](https://github.com/scientist-softserv/utk-hyku/assets/10081604/61339135-7e7f-4ed1-85c9-c01408de083f)


# Expected Behavior After Changes

<img width="1389" alt="image" src="https://github.com/scientist-softserv/utk-hyku/assets/10081604/69780b78-3218-4256-8d18-37445e652a48">

### featured_works is not an option for the dc tenant

![image](https://github.com/scientist-softserv/utk-hyku/assets/10081604/7d3138a2-de10-460a-a104-dac989ee8de4)


## QA tenant

### featured_works is an option

![image](https://github.com/scientist-softserv/utk-hyku/assets/10081604/9543073b-fba1-418b-99bd-41c91a5e1cce)











# Notes