### PR TITLE
:broom: add delete to checkbox label

### DIFF
--- a/app/views/hyrax/dashboard/collections/_list_collections.html.erb
+++ b/app/views/hyrax/dashboard/collections/_list_collections.html.erb
@@ -1,0 +1,75 @@
+<% #OVERRIDE Hyrax 3.5.0 to update batch checkbox local %>
+<% # used by All and Managed Collections tabs %>
+<% id = collection_presenter.id %>
+<tr id="document_<%= id %>"
+  data-id="<%= id %>"
+  data-colls-hash="<%= available_parent_collections_data(collection: collection_presenter) %>"
+  data-post-url="<%= hyrax.dashboard_create_nest_collection_within_path(id) %>"
+  data-post-delete-url="<%= is_admin_set ? hyrax.admin_admin_set_path(id) : hyrax.dashboard_collection_path(id) %>">
+
+  <td>
+    <label class="sr-only" for="batch_document_<%= id %>"><%= t('hyrax.dashboard.my.sr.collections_batch_checkbox') %></label>
+    <% if collection_presenter.allow_batch? %>
+    <input type="checkbox" name="batch_document_ids[]" id="batch_document_<%= id %>" value="<%= id %>" class="batch_document_selector"
+      data-hasaccess="<%= (can?(:edit, collection_presenter.solr_document)) %>" />
+    <% else %>
+    <input type="checkbox" class="disabled" disabled=true />
+    <% end %>
+  </td>
+  <td>
+    <div class="thumbnail-title-wrapper">
+      <div class="thumbnail-wrapper">
+        <% if (collection_presenter.thumbnail_path == nil) %>
+          <span class="<%= Hyrax::ModelIcon.css_class_for(::Collection) %> collection-icon-small"></span>
+        <% else %>
+          <%= image_tag(collection_presenter.thumbnail_path, alt: "#{collection_presenter.title_or_label} #{t('hyrax.dashboard.my.sr.thumbnail')}") %>
+        <% end %>
+      </div>
+      <%= link_to collection_presenter.show_path do %>
+          <span class="sr-only"><%= t("hyrax.dashboard.my.sr.show_label") %> </span>
+          <%= collection_presenter.title_or_label %>
+      <% end %>
+
+      <%# Expand arrow %>
+      <a href="#" class="small show-more" title="Click for more details">
+        <i id="expand_<%= id %>" class="glyphicon glyphicon-chevron-right" aria-hidden="true"></i>
+        <span class="sr-only"> <%= "#{t("hyrax.dashboard.my.sr.detail_label")} #{collection_presenter.title_or_label}" %></span>
+      </a>
+    </div>
+
+    <%# Collection details %>
+    <div id="detail_<%= id %>">
+      <div class="expanded-details">
+        <p>
+          <strong><%= t("hyrax.dashboard.my.collection_list.description") %></strong>
+          <br /><%= collection_presenter.description&.first %>
+        </p>
+        <p>
+          <strong><%= t("hyrax.dashboard.my.collection_list.edit_access") %></strong>
+          <br />
+          <% if collection_presenter.edit_groups.present? %>
+            <%= t("hyrax.dashboard.my.collection_list.groups") %> <%= collection_presenter.edit_groups.join(', ') %>
+            <br />
+          <% end %>
+          <%= t("hyrax.dashboard.my.collection_list.users") %> <%= collection_presenter.edit_people.join(', ') %>
+        </p>
+      </div>
+    </div>
+  </td>
+  <% if !current_ability.admin? %>
+    <td><%= collection_presenter.managed_access %></td>
+  <% end %>
+  <td class="collection_type">
+    <%= collection_presenter.collection_type_badge %>
+  </td>
+  <td class="date"><%= collection_presenter.modified_date %></td>
+  <td><%= collection_presenter.total_viewable_items %></td>
+  <td><%= collection_presenter.permission_badge %>  </td>
+  <td>
+    <% if collection_presenter.solr_document.admin_set? %>
+      <%= render '/hyrax/my/admin_set_action_menu', admin_set_presenter: collection_presenter %>
+    <% else %>
+      <%= render '/hyrax/my/collection_action_menu', collection_presenter: collection_presenter %>
+    <% end %>
+   </td>
+</tr>

--- a/app/views/hyrax/my/collections/_list_collections.html.erb
+++ b/app/views/hyrax/my/collections/_list_collections.html.erb
@@ -1,0 +1,74 @@
+<% #OVERRIDE Hyrax 3.5.0 to update batch checkbox local %>
+<% # used by Your Collections tab %>
+<% id = collection_presenter.id %>
+<%# Data attributes referenced by the javascript for submitting nested forms. %>
+<tr id="document_<%= id %>"
+  data-source="my"
+  data-id="<%= id %>"
+  data-colls-hash="<%= available_parent_collections_data(collection: collection_presenter) %>"
+  data-post-url="<%= hyrax.dashboard_create_nest_collection_within_path(id) %>"
+  data-post-delete-url="<%= is_admin_set ? hyrax.admin_admin_set_path(id) : hyrax.dashboard_collection_path(id) %>">
+
+  <td>
+    <label class="sr-only" for="batch_document_<%= id %>"><%= t('hyrax.dashboard.my.sr.collections_batch_checkbox') %></label>
+    <% if collection_presenter.allow_batch? %>
+        <input type="checkbox" name="batch_document_ids[]" id="batch_document_<%= id %>" value="<%= id %>" class="batch_document_selector"
+               data-hasaccess="<%= (can?(:edit, collection_presenter.solr_document)) %>" />
+    <% else %>
+        <input type="checkbox" class="disabled" disabled=true />
+    <% end %>
+  </td>
+  <td>
+    <div class="thumbnail-title-wrapper">
+      <div class="thumbnail-wrapper">
+        <% if (collection_presenter.thumbnail_path == nil) %>
+          <span class="<%= Hyrax::ModelIcon.css_class_for(::Collection) %> collection-icon-small"></span>
+        <% else %>
+          <%= image_tag(collection_presenter.thumbnail_path, alt: "#{collection_presenter.title_or_label} #{t('hyrax.dashboard.my.sr.thumbnail')}") %>
+        <% end %>
+      </div>
+      <%= link_to collection_presenter.show_path, id: "src_copy_link#{id}" do %>
+        <span class="sr-only"><%= t("hyrax.dashboard.my.sr.show_label") %></span>
+        <%= collection_presenter.title_or_label %>
+      <% end %>
+
+      <%# Expand arrow %>
+      <a href="#" class="small show-more" title="Click for more details">
+        <i id="expand_<%= id %>" class="glyphicon glyphicon-chevron-right" aria-hidden="true"></i>
+        <span class="sr-only"> <%= "#{t("hyrax.dashboard.my.sr.detail_label")} #{collection_presenter.title_or_label}" %></span>
+      </a>
+    </div>
+
+    <%# Collection details %>
+    <div id="detail_<%= id %>">
+      <div class="expanded-details">
+        <p>
+          <strong><%= t("hyrax.dashboard.my.collection_list.description") %></strong>
+          <br /><%= collection_presenter.description&.first %>
+        </p>
+        <p>
+          <strong><%= t("hyrax.dashboard.my.collection_list.edit_access") %></strong>
+          <br />
+          <% if collection_presenter.edit_groups.present? %>
+            <%= t("hyrax.dashboard.my.collection_list.groups") %> <%= collection_presenter.edit_groups.join(', ') %>
+            <br />
+          <% end %>
+          <%= t("hyrax.dashboard.my.collection_list.users") %> <%= collection_presenter.edit_people.join(', ') %>
+        </p>
+      </div>
+    </div>
+  </td>
+  <td class="collection_type">
+    <%= collection_presenter.collection_type_badge %>
+  </td>
+  <td class="date"><%= collection_presenter.modified_date %> </td>
+  <td><%= collection_presenter.total_viewable_items %></td>
+  <td><%= collection_presenter.permission_badge %></td>
+  <td>
+    <% if collection_presenter.solr_document.admin_set? %>
+      <%= render '/hyrax/my/admin_set_action_menu', admin_set_presenter: collection_presenter %>
+    <% else %>
+      <%= render 'hyrax/my/collection_action_menu', collection_presenter: collection_presenter %>
+    <% end %>
+   </td>
+</tr>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -689,7 +689,7 @@ en:
         highlighted: My Highlights
         shared: Works Shared with Me
         sr:
-          batch_checkbox: Check to add to a collection or edit list
+          batch_checkbox: Check to edit, delete or add to a collection.
           check_all_label: Select all files to be added to a collection or edited
           detail_label: Display summary details of
           listing: Listing of items you have deposited in

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -689,7 +689,8 @@ en:
         highlighted: My Highlights
         shared: Works Shared with Me
         sr:
-          batch_checkbox: Check to edit, delete or add to a collection.
+          batch_checkbox: Check to batch edit, delete or add to a collection.
+          collections_batch_checkbox: Check to batch delete collections. 
           check_all_label: Select all files to be added to a collection or edited
           detail_label: Display summary details of
           listing: Listing of items you have deposited in


### PR DESCRIPTION
# Story

[i40] Delete was missing from the description of the checkbox label, causing it to fail the accessibility audit.

- Issue: https://github.com/scientist-softserv/utk-hyku/issues/40

# Expected Behavior Before Changes
![image](https://github.com/scientist-softserv/utk-hyku/assets/10081604/c8950707-8a13-47a9-9134-bae676a8d7e7)


# Expected Behavior After Changes
### COLLECTIONS
![image](https://github.com/scientist-softserv/utk-hyku/assets/10081604/8ee57375-c32c-4adc-b380-7662330013fc)


### MY COLLECTIONS 
![image](https://github.com/scientist-softserv/utk-hyku/assets/10081604/dffe9d74-df2c-4656-83e4-719930296b44)


### WORKS
- [ ] delete is added to the label

![image](https://github.com/scientist-softserv/utk-hyku/assets/10081604/302b587a-8fcc-4896-b66f-ca7e11f04190)




# Notes

we are trying to hit a deadline for UTK. I created a separate ticket to contribute this back to hyku and to run translations towards the end of the milestone. 