### PR TITLE
I478 search results page responsive design

### DIFF
--- a/app/assets/stylesheets/themes/dc_repository.scss
+++ b/app/assets/stylesheets/themes/dc_repository.scss
@@ -2122,5 +2122,35 @@ body.dc_repository {
       }
     }
   }
+
+  @media (max-width: 575px ) {
+    #masthead #library-link {
+      font-size: 16px !important;
+    }
+
+    .nav > li > a {
+      padding: 10px 0;
+    }
+
+    .nav > li > .notify-number {
+      position: relative;
+      top: 2px;
+      right: -25px;
+    }
+
+    .nav > li:last-child {
+      position: relative;
+      top: 1px;
+    }
+
+    .label, td.status span {
+      padding: 0.2em 0.5em 0.3em;
+      font-size: 60%;
+      position: relative;
+      top: 6px;
+      right: 13px;
+      z-index: -1;
+    }
+  }
 }
 /**** End Responsive Styles ****/

--- a/app/assets/stylesheets/themes/dc_repository.scss
+++ b/app/assets/stylesheets/themes/dc_repository.scss
@@ -2125,7 +2125,7 @@ body.dc_repository {
 
   @media (max-width: 575px ) {
     #masthead #library-link {
-      font-size: 16px !important;
+      font-size: $type-3 !important;
     }
 
     .nav > li > a {
@@ -2160,6 +2160,23 @@ body.dc_repository {
       .utk-description {
         font-size: $type-2;
       }
+    }
+
+    .search-submit-text {
+      display: none;
+    }
+
+    #search-form-header .input-group-btn #search-submit-header {
+      min-width: 0;
+      padding: 0 12px;
+    }
+
+    nav.navbar.navbar-default.navbar-static-top .container-fluid .row {
+      padding: 0;
+    }
+
+    #search-bar {
+      padding: 4px 0 0 0;
     }
   }
 }

--- a/app/assets/stylesheets/themes/dc_repository.scss
+++ b/app/assets/stylesheets/themes/dc_repository.scss
@@ -1863,6 +1863,22 @@ body.dc_repository {
       min-height: 213px !important;
     }
 
+    .navbar-nav .open .dropdown-menu {
+      li > a {
+        color: #006c93;
+        padding: 3px 20px;
+
+        &:hover {
+          color: #812948;
+          background-color: #F5F5F5;
+        }
+      }
+
+      .divider {
+        background-color: #e5e5e5;
+      }
+    }
+
     // Featured Collections Grid
     #featured-collections {
       .featured-collections {
@@ -2077,6 +2093,33 @@ body.dc_repository {
       position: relative;
       left: 12px;
     }
+
+    #language-dropdown-menu {
+      background-color: #ffffff;
+      position: absolute;
+      left: -120px;
+      top: 41px;
+    }
+
+    .open .dropdown-menu {
+      z-index: 1000;
+      float: left;
+      min-width: 160px;
+      padding: 5px 0;
+      margin: 2px 0 0;
+      font-size: 14px;
+      text-align: left;
+      list-style: none;
+      background-clip: padding-box;
+      border: 1px solid rgba(0, 0, 0, 0.15);
+      -webkit-box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
+      box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
+      position: absolute;
+      background-color: #fff;
+      top: 31px;
+    }
+
+
   }
 
   @media (max-width: 575px) {
@@ -2213,6 +2256,19 @@ body.dc_repository {
       * {
         margin: 1px 1px;
       }
+    }
+
+    .open .dropdown-menu {
+      scale: 1.5;
+      top: 58px;
+    }
+
+    #language-dropdown-menu {
+      scale: 1.5;
+      background-color: #ffffff;
+      position: absolute;
+      left: -163px;
+      top: 100px;
     }
   }
 }

--- a/app/assets/stylesheets/themes/dc_repository.scss
+++ b/app/assets/stylesheets/themes/dc_repository.scss
@@ -2074,6 +2074,8 @@ body.dc_repository {
 
     .header-actions {
       height: 60px;
+      position: relative;
+      left: 12px;
     }
   }
 
@@ -2192,6 +2194,25 @@ body.dc_repository {
 
     #search-bar {
       padding: 0;
+    }
+
+    .page_links, .search-widgets {
+      position: relative;
+      top: -13px;
+      padding: 0;
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: center;
+
+      * {
+        margin: 0 3px;
+      }
+    }
+
+    .search-widgets {
+      * {
+        margin: 1px 1px;
+      }
     }
   }
 }

--- a/app/assets/stylesheets/themes/dc_repository.scss
+++ b/app/assets/stylesheets/themes/dc_repository.scss
@@ -76,6 +76,8 @@ body.dc_repository {
 
   /**** Header Section ****/
   #masthead {
+    box-shadow: 0 2px 5px rgba(51, 51, 51, 0.15);
+
     .container-fluid {
       display: flex;
       justify-content: space-between;
@@ -1827,6 +1829,8 @@ body.dc_repository {
 
     // Header
     #masthead {
+      height: 60px;
+
       .container-fluid {
         padding: 0 $golden-ratio-2 !important;
       }
@@ -1839,6 +1843,9 @@ body.dc_repository {
       #library-link {
         padding: 0 $golden-ratio-1 !important;
         font-size: $type-4 !important;
+        position: relative;
+        top: -6px;
+        left: 0;
       }
 
       a#utk-lib-menu {
@@ -1850,6 +1857,10 @@ body.dc_repository {
           height: 29.85px !important;
         }
       }
+    }
+
+    .title-masthead {
+      min-height: 213px !important;
     }
 
     // Featured Collections Grid
@@ -2060,6 +2071,10 @@ body.dc_repository {
         font-size: $type-3;
       }
     }
+
+    .header-actions {
+      height: 60px;
+    }
   }
 
   @media (max-width: 575px) {
@@ -2176,7 +2191,7 @@ body.dc_repository {
     }
 
     #search-bar {
-      padding: 4px 0 0 0;
+      padding: 0;
     }
   }
 }

--- a/app/assets/stylesheets/themes/dc_repository.scss
+++ b/app/assets/stylesheets/themes/dc_repository.scss
@@ -2151,6 +2151,16 @@ body.dc_repository {
       right: 13px;
       z-index: -1;
     }
+
+    .utk-digital-elements-wrapper .row .utk-digital-search-container .utk-digital-search-heading {
+      .utk-heading-1 {
+        font-size: $type-4;
+      }
+
+      .utk-description {
+        font-size: $type-2;
+      }
+    }
   }
 }
 /**** End Responsive Styles ****/

--- a/app/views/shared/_locale_picker.html.erb
+++ b/app/views/shared/_locale_picker.html.erb
@@ -1,0 +1,20 @@
+<%# OVERRID Hyrax 3.5.0 to shorten language to abbreviations %>
+
+<li class="nav-item dropdown">
+    <a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false" aria-controls="language-dropdown-menu">
+        <span class="sr-only"><%= t('hyrax.toolbar.language_switch') %></span>
+        <%# OVERRIDE begin %>
+        <span title="<%= t('hyrax.toolbar.language_switch') %>"><%= I18n.locale.to_s.upcase %></span>
+        <%# OVERRIDE end %>
+        <b class="caret"></b>
+    </a>
+    <ul id="language-dropdown-menu" class="dropdown-menu" role="menu">
+        <li role="presentation" class="dropdown-header"><%= t('hyrax.toolbar.language_switch') %></li>
+        <li role="presentation" class="divider"></li>
+        <% available_translations.each do |language, label| %>
+            <li role="presentation" lang="<%= language %>">
+                <%= link_to label, "?locale=#{language}", class: 'dropdown-item', role: 'menuitem', tabindex: '-1', data: { locale: language } %>
+            </li>
+        <% end %>
+    </ul>
+</li>

--- a/app/views/themes/dc_repository/_controls.html.erb
+++ b/app/views/themes/dc_repository/_controls.html.erb
@@ -8,11 +8,11 @@
           <%= link_to t(:'hyrax.controls.home'), hyrax.root_path, aria: current_page?(hyrax.root_path) ? {current: 'page'} : nil %></li>
         <li <%= 'class=active' if current_page?(hyrax.about_path) %>>
           <%= link_to t(:'hyrax.controls.about'), hyrax.about_path, aria: current_page?(hyrax.about_path) ? {current: 'page'} : nil %></li>
-        <%# OVERRIDE: Hyrax v3.4.1 Remove 'help' from nav %>  
+        <%# OVERRIDE: Hyrax v3.4.1 Remove 'help' from nav %>
         <li <%= 'class=active' if current_page?(hyrax.contact_path) %>>
           <%= link_to t(:'hyrax.controls.contact'), hyrax.contact_path, aria: current_page?(hyrax.contact_path) ? {current: 'page'} : nil %></li>
       </ul><!-- /.nav -->
-      <div class="searchbar-right navbar-right col-sm-7">
+      <div class="searchbar-right navbar-right col-sm-7" id="search-bar">
         <%= render partial: '/themes/dc_repository/catalog/search_form' %>
       </div>
     </div>

--- a/app/views/themes/dc_repository/catalog/_search_form.html.erb
+++ b/app/views/themes/dc_repository/catalog/_search_form.html.erb
@@ -36,10 +36,11 @@
 
         </ul>
         <button type="submit" class="btn" id="search-submit-header">
-          <%= t('hyrax.search.button.html') %>
+          <span class="glyphicon glyphicon-search"></span>
+          <span class="search-submit-text"><%= t('hyrax.search.button.text') %></span>
         </button>
       </div><!-- /.input-group-btn -->
     </div><!-- /.input-group -->
-    
+
   </div><!-- /.form-group -->
 <% end %>


### PR DESCRIPTION
# Story

- [x] **Header Logo**: The logo and 'libraries' do not break onto separate lines 
- [x] **"Digital Collections" Header**: The entire "Digital Collections: Explore items digitized from our collections." is visible and has appropriate padding
- [x] **Search Bar**: Search bar does not have contents cut-off
- [x] **Page Number and Sort**: `Previous | number of number | Next` are on one line and sorting options, number of items per page option, and link/grid option are centered or all on one line
- [x] **Expanded language options**: when language options are expanded, the logo and 'libraries' do not break onto separate lines and the options look cohesive
- [x] **Expanded login options**: when login options are expanded, the llogo and 'libraries' do not break onto separate lines and the options look cohesive

Refs: https://github.com/scientist-softserv/utk-hyku/issues/478
also closes: https://github.com/scientist-softserv/utk-hyku/issues/480

# Expected Behavior Before Changes
- Header elements was not aligned at a small resolution
- Login menu was not styled
- Select language menu was also not styled
- Digital Collections text was too big to fit inside its boundaries
- Search bar was too narrow and cut off
- Page number and sorting actions were not aligned

# Expected Behavior After Changes

- Header elements are now aligned and fit into a smaller width
  - The language text was changed to just use the language abbreviations to fit this better
- Login menu was styled in a similar manner as in the bigger width display
  - The menu was scaled up by 1.5x at smaller widths
- Select language menu was also adjusted similarly
- Digital Collections text was made smaller so it doesn't overflow its boundaries
- Search bar was made wider
- Page number and sorting actions are center aligned
- Header now has a drop shadow making the separation between header and body visible
- Header is now slightly shorter at smaller resolutions to take up a little less space

## Video Captured at 320x480
Before:

https://github.com/scientist-softserv/utk-hyku/assets/19597776/a02a2e5d-d2f4-4c4b-8fbb-774034453b4c



After:

https://github.com/scientist-softserv/utk-hyku/assets/19597776/e9f5909e-ae31-4436-a391-c83e2cf96ccf

