### PR TITLE
🐛 update bulkrax to pull in fix for dropdown bug

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -85,7 +85,7 @@ group :development do
   # gem 'xray-rails' # when using this gem, know that sidekiq will not work
 end
 
-gem 'bulkrax', git: 'https://github.com/samvera-labs/bulkrax.git', ref: 'a8f6c16'
+gem 'bulkrax', git: 'https://github.com/samvera-labs/bulkrax.git', ref: '6c67f16'
 
 gem 'allinson_flex', git: 'https://github.com/samvera-labs/allinson_flex.git'
 gem 'blacklight', '~> 6.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,8 +10,8 @@ GIT
 
 GIT
   remote: https://github.com/samvera-labs/bulkrax.git
-  revision: a8f6c16b392a6ed1197cbeb90b82400b428d584b
-  ref: a8f6c16
+  revision: 6c67f16fb922e22dc11552e670f4b90bc5379e4a
+  ref: 6c67f16
   specs:
     bulkrax (5.2.1)
       bagit (~> 0.4)


### PR DESCRIPTION
# Story

We recently discovered a bug with the drop down menu that was caused by a bulkrax commit.

ref: https://github.com/samvera-labs/bulkrax/commit/32dace913d2400596c8f93ea01e891945103ce49

We reverted this commit from bulkrax and are updating the gem to pull in the fix.

Issue
- https://github.com/scientist-softserv/utk-hyku/issues/491

# Expected Behavior Before Changes

User was unable to expand header drop downs

# Expected Behavior After Changes
![image](https://github.com/scientist-softserv/utk-hyku/assets/10081604/aff09802-ede6-4df4-a22d-be26b0ccbc12)

![image](https://github.com/scientist-softserv/utk-hyku/assets/10081604/88483bfe-3fb8-4225-bc09-47611515f4d1)
