### PR TITLE
i481 Make Home About Contact links appear

### DIFF
--- a/app/assets/stylesheets/themes/dc_repository.scss
+++ b/app/assets/stylesheets/themes/dc_repository.scss
@@ -1601,9 +1601,11 @@ body.dc_repository {
         justify-content: center;
 
         .navbar-nav {
-          display: none;
           margin: 0;
           padding: 0;
+          display: flex;
+          width:90%;
+          justify-content: space-evenly;
         }
 
         .row {
@@ -1785,6 +1787,24 @@ body.dc_repository {
   }
 
   @media (max-width: 767px) {
+    .image-masthead {
+      .controls,
+      .container-fluid,
+      .row {
+        height: 100px;
+      }
+
+      .row {
+        flex-direction: column;
+      }
+    }
+
+    .utk-digital-elements-wrapper {
+      height: 76px !important;
+      position: relative;
+      top: 24px;
+    }
+
     // Search Results
     .search-container {
       width: 85%;
@@ -2240,8 +2260,6 @@ body.dc_repository {
     }
 
     .page_links, .search-widgets {
-      position: relative;
-      top: -13px;
       padding: 0;
       display: flex;
       flex-wrap: wrap;


### PR DESCRIPTION
# Story

This commit will make the Home, About, and Contact links visible for
mobile users.

Ref:
  - https://github.com/scientist-softserv/utk-hyku/issues/481

# Expected Behavior Before Changes

Mobile users were not able to access the Home, About, and Contact links.

# Expected Behavior After Changes

Mobile users can access the Home, About, and Contact links.

# Screenshots / Video

### Before:
<img width="331" alt="image" src="https://github.com/scientist-softserv/utk-hyku/assets/19597776/ab3a0473-d87d-45a0-9f3a-d350afc05a63">


### After:
<img width="330" alt="image" src="https://github.com/scientist-softserv/utk-hyku/assets/19597776/5c7cda67-c4e4-45f8-80e2-87e092a119be">
