### PR TITLE
I479 mobile friendly work show pg

### DIFF
--- a/app/assets/stylesheets/themes/dc_show.scss
+++ b/app/assets/stylesheets/themes/dc_show.scss
@@ -285,12 +285,12 @@ body.dc_show {
       width: 120%;
     }
 
-    .uv-panel {
-      padding: 0 !important;
+    .col-xs-12 .uv-panel {
+      padding: 0;
     }
 
-    .thumbnail {
-      width: 80px !important;
+    .works-panel .panel-body .table tr .thumbnail {
+      width: 80px;
     }
   }
   /**** End Responsive Styles ****/

--- a/app/assets/stylesheets/themes/dc_show.scss
+++ b/app/assets/stylesheets/themes/dc_show.scss
@@ -230,7 +230,7 @@ body.dc_show {
     }
 
     .works-panel {
-      padding: 0 $golden-ratio-3;
+      padding: 0px 12px;
 
       .panel-heading {
         .panel-title {
@@ -253,7 +253,7 @@ body.dc_show {
           }
 
           .thumbnail {
-            width: 100px !important;
+            width: 100px
           }
 
           .attribute {
@@ -277,6 +277,20 @@ body.dc_show {
           font-size: $type-2 !important;
         }
       }
+    }
+  }
+
+  @media (max-width: 575px ) {
+    .work-type-container {
+      width: 120%;
+    }
+
+    .uv-panel {
+      padding: 0 !important;
+    }
+
+    .thumbnail {
+      width: 80px !important;
     }
   }
   /**** End Responsive Styles ****/

--- a/public/clover-iiif/static/css/main.e6c13ad2.css
+++ b/public/clover-iiif/static/css/main.e6c13ad2.css
@@ -1,2 +1,19 @@
-body{-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Oxygen,Ubuntu,Cantarell,Fira Sans,Droid Sans,Helvetica Neue,sans-serif;margin:0}code{font-family:source-code-pro,Menlo,Monaco,Consolas,Courier New,monospace}
+body {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen,
+    Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
+  margin: 0;
+}
+code {
+  font-family: source-code-pro, Menlo, Monaco, Consolas, Courier New, monospace;
+}
+
+/* Responsive display, if upgrading Clover-IIIF, bring this change as well */
+@media (max-width: 575px) {
+  .clover-header {
+    align-items: end;
+    flex-direction: column;
+  }
+}
 /*# sourceMappingURL=main.e6c13ad2.css.map*/


### PR DESCRIPTION
# Story

[🎁 Make work show page mobile friendly](https://github.com/scientist-softserv/utk-hyku/commit/44df24123a712aa98d711f89ac2aa5140c72ffd9) 

This commit will add styling to the work show page that make the mobile
viewing experience better.

Ref:
  - https://github.com/scientist-softserv/utk-hyku/issues/479

---

[🎁 Adjust Clover-IIIF css](https://github.com/scientist-softserv/utk-hyku/commit/87bd5b1ccee7d8be6a6d7ecd7df5b002c09e1d4e) 

This commit will target the css inside the iframe which belongs to the
Clover-IIIF viewer.  The header should now be mobile friendly.

# Expected Behavior Before Changes

- work show page had a horizontal scroll on smaller displays
- Clover-IIIF viewer had cut off headers and IIIF manifest badge is not visible on smaller displays

# Expected Behavior After Changes

- work show page should no longer have horizontal scrolling
- text generally takes up more of the empty space so information can fit better
- Clover-IIIF header is not cut off and IIIF manifest badge is still visible even on smaller displays

# Screenshots / Video

<details>
<summary>Before (UV)</summary>

https://github.com/scientist-softserv/utk-hyku/assets/19597776/59dd3dfa-af5c-412d-8e55-e10f591aad88

</details>

<details>
<summary>Before (Clover-IIIF)</summary>

https://github.com/scientist-softserv/utk-hyku/assets/19597776/2249f6a5-31a3-488d-b5bd-a8f41097c3b8

</details>

<details>
<summary>After (UV)</summary>

https://github.com/scientist-softserv/utk-hyku/assets/19597776/cef25b57-53ef-4e16-9bd9-1f5555f5b319

</details>

<details>
<summary>After (Clover-IIIF)</summary>

https://github.com/scientist-softserv/utk-hyku/assets/19597776/ea4e47cf-2c60-4682-8225-191ae82dfd50

</details>
