### PR TITLE
:bug: flip logic for when to display feature button on works show page

### DIFF
--- a/app/views/hyrax/base/_show_actions.html.erb
+++ b/app/views/hyrax/base/_show_actions.html.erb
@@ -10,7 +10,7 @@
                       data: { toggle: "modal", target: "#collection-list-container" } %>
       <% end %>
       <%# OVERRIDE begin %>
-      <% if presenter.work_featurable? && AccountsHelper::TENANTS_WITH_NO_WORK_FEATURES.include?(@current_account.name) %>
+      <% if presenter.work_featurable? && !AccountsHelper::TENANTS_WITH_NO_WORK_FEATURES.include?(@current_account.name) %>
         <%= link_to t('.feature'), hyrax.featured_work_path(presenter, format: :json),
             data: { behavior: 'feature' },
             class: presenter.display_feature_link? ? 'btn btn-default' : 'btn btn-default collapse' %>


### PR DESCRIPTION
# Story

ref QA feedback. I had the logic swapped on the work show page, for when the feature button should be available. 

ref https://github.com/scientist-softserv/utk-hyku/issues/472#issuecomment-1652127218

Refs 
- https://github.com/scientist-softserv/utk-hyku/issues/472





# Screenshots / Video

<details>
<summary> Non DC tenant work show page has Feature button </summary>


<img width="1024" alt="image" src="https://github.com/scientist-softserv/utk-hyku/assets/10081604/3e492b04-537d-4150-a37e-ae9b7c870c46">

</details>

<details>
<summary> DC work show page does not have Feature button </summary>


<img width="1273" alt="image" src="https://github.com/scientist-softserv/utk-hyku/assets/10081604/a4026cda-ac38-4fb5-878b-c1fa562ad71f">


</details>
