### PR TITLE
🎁 Install omniauth-cas and configure devise

### DIFF
--- a/.env
+++ b/.env
@@ -53,3 +53,7 @@ GOOGLE_OAUTH_CLIENT_EMAIL=hyku-analytics@hyku-analytics.iam.gserviceaccount.com
 
 # Uncomment and set to true to access Create/Edit UI for allinson flex profiles
 # DISPLAY_ALLINSON_FLEX_UI=false
+
+CAS_HOST=cas.tennessee.edu
+CAS_LOGIN_URL=/cas/login
+CAS_EMAIL_DOMAIN=utk.edu

--- a/Gemfile
+++ b/Gemfile
@@ -111,6 +111,8 @@ gem 'devise-guests', '~> 0.3'
 gem 'devise-i18n'
 gem 'devise_invitable', '~> 1.6'
 
+gem 'omniauth-cas', '~> 2.0'
+
 gem 'apartment'
 gem 'is_it_working'
 gem 'rolify'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -850,6 +850,13 @@ GEM
     oj (3.13.16)
     oj_mimic_json (1.0.1)
     okcomputer (1.18.4)
+    omniauth (1.9.2)
+      hashie (>= 3.4.6)
+      rack (>= 1.6.2, < 3)
+    omniauth-cas (2.0.0)
+      addressable (~> 2.3)
+      nokogiri (~> 1.5)
+      omniauth (~> 1.2)
     openseadragon (0.6.0)
       rails (> 3.2.0)
     optimist (3.0.1)
@@ -1345,6 +1352,7 @@ DEPENDENCIES
   lograge
   mods (~> 2.4)
   okcomputer
+  omniauth-cas (~> 2.0)
   parser (~> 2.5.3)
   pg
   postrank-uri (>= 1.0.24)

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,0 +1,36 @@
+class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
+    skip_before_action :verify_authenticity_token, only: [:cas, :developer]
+
+    def cas
+      # You need to implement the method below in your model (e.g. app/models/user.rb)
+      @user = User.find_for_cas(request.env["omniauth.auth"])
+
+      if @user.persisted?
+        sign_in_and_redirect @user, event: :authentication # this will throw if @user is not activated
+        set_flash_message(:notice, :success, kind: "CAS") if is_navigational_format?
+      else
+        session["devise.cas_data"] = request.env["omniauth.auth"].except(:extra) # Removing extra as it can overflow some session stores
+        redirect_to new_user_registration_url
+      end
+    end
+
+    def failure
+      redirect_to root_path
+    end
+
+    def developer
+      if Rails.env.production?
+        redirect_to root_path
+      else
+        @user = User.find_for_developer(request.env["omniauth.auth"])
+
+        if @user.persisted?
+          sign_in_and_redirect @user, event: :authentication # this will throw if @user is not activated
+          set_flash_message(:notice, :success, kind: "DEVELOPER") if is_navigational_format?
+        else
+          session["devise.developer_data"] = request.env["omniauth.auth"].except(:extra) # Removing extra as it can overflow some session stores
+          redirect_to new_user_registration_url
+        end
+      end
+    end
+end

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,27 +1,9 @@
 <%# OVERRIDE /usr/local/bundle/gems/devise-i18n-1.10.2/app/views/devise/sessions/new.html.erb to add customization to log in page %>
+<%# OVERRIDE because we are using CAS, we get rid of the sign in form %>
 
 <h2 class="">Log in</h2>
 <div class="row">
   <div class="col-md-4">
-    <%= form_for(resource, as: resource_name, url: session_path(resource_name), class: "form-horizontal") do |f| %>
-      <div class="form-group">
-        <%= f.label :email %><br />
-        <%= f.email_field :email, autofocus: true, class: "form-control" %>
-      </div>
-      <div class="form-group">
-        <%= f.label :password, class: "control-label" %><br />
-        <%= f.password_field :password, autocomplete: "off", class: "form-control" %>
-      </div>
-      <% if devise_mapping.rememberable? -%>
-        <div class="form-group">
-          <%= f.check_box :remember_me %>
-          <%= f.label :remember_me, class: "control-label" %>
-        </div>
-      <% end -%>
-      <div class="form-group">
-        <%= f.submit "Log in", class: 'btn btn-primary devise-button' %>
-      </div>
-    <% end %>
     <div class="">
       <%= render "devise/shared/links" %>
     </div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,9 +1,27 @@
 <%# OVERRIDE /usr/local/bundle/gems/devise-i18n-1.10.2/app/views/devise/sessions/new.html.erb to add customization to log in page %>
-<%# OVERRIDE because we are using CAS, we get rid of the sign in form %>
 
 <h2 class="">Log in</h2>
 <div class="row">
   <div class="col-md-4">
+    <%= form_for(resource, as: resource_name, url: session_path(resource_name), class: "form-horizontal") do |f| %>
+      <div class="form-group">
+        <%= f.label :email %><br />
+        <%= f.email_field :email, autofocus: true, class: "form-control" %>
+      </div>
+      <div class="form-group">
+        <%= f.label :password, class: "control-label" %><br />
+        <%= f.password_field :password, autocomplete: "off", class: "form-control" %>
+      </div>
+      <% if devise_mapping.rememberable? -%>
+        <div class="form-group">
+          <%= f.check_box :remember_me %>
+          <%= f.label :remember_me, class: "control-label" %>
+        </div>
+      <% end -%>
+      <div class="form-group">
+        <%= f.submit "Log in", class: 'btn btn-primary devise-button' %>
+      </div>
+    <% end %>
     <div class="">
       <%= render "devise/shared/links" %>
     </div>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -289,7 +289,13 @@ Devise.setup do |config|
   # ==> OmniAuth
   # Add a new OmniAuth provider. Check the wiki for more information on setting
   # up on your models and hooks.
-  # config.omniauth :github, 'APP_ID', 'APP_SECRET', scope: 'user,public_repo'
+  config.omniauth(:cas,
+                  host: ENV['CAS_HOST'],
+                  login_url: ENV['CAS_LOGIN_URL'])
+
+  config.omniauth(:developer,
+                  fields: [:net_id],
+                  uid_field: :net_id) unless Rails.env.production?
 
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,7 +41,12 @@ mount AllinsonFlex::Engine, at: '/'
 
   root 'hyrax/homepage#index'
 
-  devise_for :users, controllers: { invitations: 'hyku/invitations', registrations: 'hyku/registrations' }
+  if Rails.env.production?
+    get 'users/sign_in', to: redirect('/users/auth/cas')
+    post 'users/sign_in', to: redirect('/')
+  end
+
+  devise_for :users, controllers: { omniauth_callbacks: 'users/omniauth_callbacks' }
   mount Qa::Engine => '/authorities'
 
   mount Blacklight::Engine => '/'

--- a/db/migrate/20230727180717_add_omniauth_to_users.rb
+++ b/db/migrate/20230727180717_add_omniauth_to_users.rb
@@ -1,0 +1,6 @@
+class AddOmniauthToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :provider, :string
+    add_column :users, :uid, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_06_08_153601) do
+ActiveRecord::Schema.define(version: 2023_07_27_180717) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -920,6 +920,8 @@ ActiveRecord::Schema.define(version: 2023_06_08_153601) do
     t.integer "invited_by_id"
     t.string "invited_by_type"
     t.string "preferred_locale"
+    t.string "provider"
+    t.string "uid"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true


### PR DESCRIPTION
# Story

This commit will install the omniauth-cas gem and also configure devise to use it.  Also in this commit is adding the developer provider for easy of use without having to log in with a password in development while in production we use CAS.  This meant we want to get rid of the form in the user/sign_in route.  We will redirect to the CAS login on production.

Ref:
- https://github.com/scientist-softserv/utk-hyku/issues/2

# Expected Behavior Before Changes

# Expected Behavior After Changes

# Screenshots / Video

<details>
<summary></summary>

</details>

# Notes