### PR TITLE
I43 alt text tag followup

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/samvera-labs/allinson_flex.git
-  revision: 2141b481e2f4a35b4df87c54edf6bc7c1611bfb0
+  revision: 72e2cbeda64ea68769067ebb94ff1766101a94c3
   specs:
     allinson_flex (0.1.0)
       json_schemer

--- a/app/views/_logo.html.erb
+++ b/app/views/_logo.html.erb
@@ -1,7 +1,7 @@
 <% if logo_image %>
   <a id="logo" href="<%= hyrax.root_path %>" data-no-turbolink="true">
     <span class="glyphicon glyphicon-globe" role="img" aria-label="<%= application_name %>" aria-hidden="true"></span>
-    <%= image_tag logo_image, alt_text: block_for(name: 'logo_image_text') %>
+    <%= image_tag logo_image, alt: block_for(name: 'logo_image_text') %>
   </a>
 <% else %>
   <a id="logo" class="navbar-brand" href="<%= hyrax.root_path %>" data-no-turbolink="true">

--- a/app/views/hyrax/dashboard/collections/_list_collections.html.erb
+++ b/app/views/hyrax/dashboard/collections/_list_collections.html.erb
@@ -22,7 +22,7 @@
         <% if (collection_presenter.thumbnail_path == nil) %>
           <span class="<%= Hyrax::ModelIcon.css_class_for(::Collection) %> collection-icon-small"></span>
         <% else %>
-          <%= image_tag(collection_presenter.thumbnail_path, alt: "#{collection_presenter.title_or_label} #{t('hyrax.dashboard.my.sr.thumbnail')}") %>
+          <%= image_tag(collection_presenter.thumbnail_path, alt: block_for(name: 'default_collection_image_text') || "#{collection_presenter.title_or_label} #{t('hyrax.dashboard.my.sr.thumbnail')}") %>
         <% end %>
       </div>
       <%= link_to collection_presenter.show_path do %>

--- a/app/views/hyrax/my/collections/_list_collections.html.erb
+++ b/app/views/hyrax/my/collections/_list_collections.html.erb
@@ -24,7 +24,7 @@
         <% if (collection_presenter.thumbnail_path == nil) %>
           <span class="<%= Hyrax::ModelIcon.css_class_for(::Collection) %> collection-icon-small"></span>
         <% else %>
-          <%= image_tag(collection_presenter.thumbnail_path, alt: "#{collection_presenter.title_or_label} #{t('hyrax.dashboard.my.sr.thumbnail')}") %>
+          <%= image_tag(collection_presenter.thumbnail_path, alt: block_for(name: 'default_collection_image_text') || "#{collection_presenter.title_or_label} #{t('hyrax.dashboard.my.sr.thumbnail')}") %>
         <% end %>
       </div>
       <%= link_to collection_presenter.show_path, id: "src_copy_link#{id}" do %>


### PR DESCRIPTION
# Story

This PR will address the issues found during QA

Ref:
- https://github.com/scientist-softserv/utk-hyku/issues/471#issuecomment-1652165961

# Expected Behavior Before Changes

See [comments](https://github.com/scientist-softserv/utk-hyku/issues/471#issuecomment-1652165961)

# Expected Behavior After Changes

- `alt_text` has been changed to `alt` for the logo
- Collection and Work thumbnails have correct alt text

# Screenshots / Video

<details>
<summary>Dashboard logo</summary>

<img width="842" alt="image" src="https://github.com/scientist-softserv/utk-hyku/assets/19597776/a4ddbeee-7de5-4d1a-8020-0d38808aeee5">

</details>

<details>
<summary>Work with default thumbnail and alt text</summary>

<img width="1360" alt="Pasted image 20230727091111" src="https://github.com/samvera-labs/allinson_flex/assets/19597776/732855a8-9fea-4b56-96be-fd7c7701c228">

</details>

<details>
<summary>Work with custom thumbnail and alt text</summary>

<img width="1335" alt="image" src="https://github.com/samvera-labs/allinson_flex/assets/19597776/d5f85f06-88e2-48ae-982f-17986962be8e">

</details>

<details>
<summary>Collection with default thumbnail and alt text</summary>

<img width="1357" alt="image" src="https://github.com/scientist-softserv/utk-hyku/assets/19597776/2d8f707a-685e-4984-b990-a1064338c679">

</details>

<details>
<summary>Collection with custom thumbnail and alt text</summary>

<img width="1255" alt="image" src="https://github.com/scientist-softserv/utk-hyku/assets/19597776/7266d138-ace5-4dcc-aca7-785a23bf6e38">

</details>
