### PR TITLE
🐛 Monkey patch ordered_works

### DIFF
--- a/app/jobs/reindex_works_job.rb
+++ b/app/jobs/reindex_works_job.rb
@@ -6,8 +6,8 @@ class ReindexWorksJob < ApplicationJob
       work.update_index
     else
       Hyrax.config.registered_curation_concern_types.each do |work_type|
-        work_type.constantize.find_each do |work|
-          ReindexWorksJob.perform_later(work)
+        work_type.constantize.find_each do |w|
+          ReindexWorksJob.perform_later(w)
         end
       end
     end

--- a/app/jobs/reindex_works_job.rb
+++ b/app/jobs/reindex_works_job.rb
@@ -6,7 +6,9 @@ class ReindexWorksJob < ApplicationJob
       work.update_index
     else
       Hyrax.config.registered_curation_concern_types.each do |work_type|
-        work_type.constantize.find_each(&:update_index)
+        work_type.constantize.find_each do |work|
+          ReindexWorksJob.perform_later(work)
+        end
       end
     end
   end

--- a/config/initializers/work_behavior_override.rb
+++ b/config/initializers/work_behavior_override.rb
@@ -1,0 +1,10 @@
+# Keep for one reindex, starting 7/28/2023 and delete after done
+Hydra::Works::WorkBehavior.module_eval do
+  def ordered_works
+    if ordered_members.to_a.detect {|m| m.nil?}
+      logger = ActiveSupport::Logger.new('tmp/imports/bad_ordered_members.log')
+      logger.error(self.id)
+    end
+    ordered_members.to_a.reject{|m| m.nil?}.select(&:work?)
+  end
+end


### PR DESCRIPTION
# Story
Ref #512
Some works exist with a nil value in ordered_members, and are unable to reindex due to the call to
`descendent_member_ids_for(object)` in IiifPrint's child works indexer.

# Expected Behavior Before Changes
Reindexing production results in `undefined method `work?' for nil:NilClass`
# Expected Behavior After Changes
Reindexing production completes normally, and logs works with this error into `tmp/imports/bad_ordered_members.log`

# Screenshots / Video

<details>
<summary></summary>

</details>

# Notes