### PR TITLE
i485 admin dashboard rework

### DIFF
--- a/app/assets/javascripts/hyrax/app.js.erb
+++ b/app/assets/javascripts/hyrax/app.js.erb
@@ -165,40 +165,20 @@ Hyrax = {
 
     // Minimize/maximize the dashboard sidebar
     sidebar: function () {
-        // default behavior
-        $(window).on('load', function() {
+        $('.sidebar-toggle').on('click', function() {
+            $('.sidebar').toggleClass('maximized');
+            if ($(window).width() >= 768) {
+                $('.main-content').toggleClass('maximized');
+            }
+        });
+
+        $(window).on('resize', function() {
             if ($(window).width() >= 768) {
                 $('.sidebar, .main-content').addClass('maximized');
             } else {
                 $('.sidebar, .main-content').removeClass('maximized');
             }
-        });
-
-        $(window).on('resize', function(){
-            checkWidth();
-        })
-
-        $('.sidebar-toggle').on('click', function() {
-            $('.sidebar').toggleClass('maximized');
-
-            checkWidth();
-        });
-        
-        function checkWidth() {
-            if ($(window).width() >= 768) {
-                if ($('.sidebar').hasClass('maximized')) {
-                    $('.main-content').addClass('maximized');
-                } else if (!$('.sidebar').hasClass('maximized')) {
-                    $('.main-content').removeClass('maximized');
-                };
-            } else {
-                if ($('.sidebar').hasClass('maximized')) {
-                    $('.main-content').removeClass('maximized');
-                } else if (!$('.sidebar').hasClass('maximized')) {
-                    $('.main-content').removeClass('maximized');
-                };
-            }
-        }
+        }).trigger('resize');
     },
     // OVERRIDE end
 

--- a/app/assets/javascripts/hyrax/app.js.erb
+++ b/app/assets/javascripts/hyrax/app.js.erb
@@ -172,6 +172,18 @@ Hyrax = {
             }
         });
 
+        $('.sidebar').on('mouseenter', function() {
+            if ($(window).width() < 768) {
+                $('.sidebar').addClass('maximized');
+            }
+        });
+
+        $('.sidebar').on('mouseleave', function() {
+            if ($(window).width() < 768) {
+                $('.sidebar').removeClass('maximized');
+            }
+        });
+
         $(window).on('resize', function() {
             if ($(window).width() >= 768) {
                 $('.sidebar, .main-content').addClass('maximized');


### PR DESCRIPTION
# Story

In the admin dashboard, the sidebar should automatically collapse when the window size is under 768px wide.

Ref:
- #41 
- #485

# Expected Behavior Before Changes
Sidebar was not automatically collapsing under 768px width.

# Expected Behavior After Changes
Sidebar now collapses under 768px and also added a mouse over to toggle when under 768px.

# Screenshots / Video

https://github.com/scientist-softserv/utk-hyku/assets/19597776/54f73b10-1f39-47cc-9010-d88b62975078
