### PR TITLE
🐛 Fix work show page margins on mobile

### DIFF
--- a/app/assets/stylesheets/themes/dc_repository.scss
+++ b/app/assets/stylesheets/themes/dc_repository.scss
@@ -1794,7 +1794,7 @@ body.dc_repository {
 
   @media (max-width: 767px) {
     // FileSet show page
-    .col-xs-12 {
+    .file-show-details {
       word-break: break-word;
     }
 
@@ -1826,6 +1826,7 @@ body.dc_repository {
 
     // Search Results
     .search-container {
+      width: 85%;
       display: flex;
       flex-direction: column;
       justify-content: center;


### PR DESCRIPTION
This commit will make the work show page look better.  The problem was that some of the file set show page css changes interfered with the work show page.

Ref:
- #517

# Screenshots / Video

Work show page table
<img width="333" alt="image" src="https://github.com/scientist-softserv/utk-hyku/assets/19597776/ddafb1cd-a18e-4b26-bbd6-73e6961f9e0d">

File set show page table
<img width="335" alt="image" src="https://github.com/scientist-softserv/utk-hyku/assets/19597776/02ff0b25-c7aa-4a79-8465-bc3cd961f399">
