### PR TITLE
I62 collection splash rework

### DIFF
--- a/app/assets/stylesheets/themes/dc_show.scss
+++ b/app/assets/stylesheets/themes/dc_show.scss
@@ -226,6 +226,11 @@ body.dc_show {
     }
   }
 
+  .hyc-blacklight.hyc-bl-search.hyc-body.row {
+    display: flex;
+    justify-content: center;
+  }
+
   // requested by the client, hide the breadcrumb on the collection show page
   #content-wrapper .breadcrumb {
     display: none;

--- a/app/helpers/hyrax/collections_helper_decorator.rb
+++ b/app/helpers/hyrax/collections_helper_decorator.rb
@@ -12,5 +12,11 @@ module Hyrax
     def collections_show?
       controller_name == 'collections' && action_name == 'show'
     end
+
+    METADATA_FOR_SHOW_PAGE = %i[abstract creator date_created date_issued keyword local_creator subject].freeze
+
+    def metadata_fields_for_show_page(presenter_terms_with_values)
+      presenter_terms_with_values.select { |field_name| METADATA_FOR_SHOW_PAGE.include?(field_name) }
+    end
   end
 end

--- a/app/views/hyrax/collections/_show_descriptions.html.erb
+++ b/app/views/hyrax/collections/_show_descriptions.html.erb
@@ -1,8 +1,8 @@
-<%# OVERRIDE Hyrax 3.5.0 hide total items badge on the collection show page %>
+<%# OVERRIDE Hyrax 3.5.0 to hide all unwanted metadata fields and remove abstract label
+    @see Hyrax::CollectionsHelperDecorator::METADATA_FOR_SHOW_PAGE %>
 
 <dl class="hyc-collection-metadata">
-  <% @presenter.terms_with_values.each do |field_name| %>
-    <% next if field_name == :total_items %>
+  <% metadata_fields_for_show_page(@presenter.terms_with_values).each do |field_name| %>
     <div id=<%= "hyc-collection-metadata-#{field_name}" %>>
       <% unless field_name == :abstract %>
         <dt><%= collection_metadata_label(@presenter, field_name) %></dt>

--- a/app/views/hyrax/collections/show.html.erb
+++ b/app/views/hyrax/collections/show.html.erb
@@ -3,7 +3,7 @@
 <div class="hyc-container" itemscope itemtype="http://schema.org/CollectionPage">
   <div class="row hyc-header">
     <div class="col-md-12">
-      <% if @presenter.banner_file.present? %>
+      <% if @presenter.banner_file[:filename] %>
       <div class='hyc-banner'>
         <%= render partial: '/themes/dc_repository/shared/collection_splash_header', locals: { bg_image: @presenter.banner_file[:relative_path], bg_title: @presenter.banner_file[:alt_text] }%>
         </div>
@@ -47,20 +47,7 @@
   <div class="row hyc-body">
     <div class="hyc-blacklight hyc-bl-title">
       <%= render 'show_descriptions' %>
-      <% unless @presenter.total_viewable_items.blank? %>
-        <div class="hyc-bugs">
-          <div class="hyc-item-count">
-            <strong><%= @presenter.total_viewable_items %></strong> <%= t('.item_count').pluralize(@presenter.total_viewable_items) %>
-            <strong> | </strong>
-            <% unless @presenter.creator.blank? %>
-              <strong> | </strong><span class="hyc-created-by">Created by: <%= @presenter.creator.first %></span>
-            <% end %>
-            <% unless @presenter.modified_date.blank? %>
-              <span class="hyc-last-updated">Last Updated: <%= @presenter.modified_date %></span>
-            <% end %>
-          </div>
-        </div>
-      <% end %>
+      <%# OVERRIDE Hyrax 2.9.1 remove item count and creator info from collection show page per client request %>
     </div>
   </div>
   <!-- Search results label -->

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -452,7 +452,7 @@ en:
         default_description: A User Collection can be created by any user to organize their works.
     collections:
       search_form:
-        button_label: Go
+        button_label: Search
         label: Search Collection %{title}
         placeholder: Search subcollections and works in this collection
       show:
@@ -690,7 +690,7 @@ en:
         shared: Works Shared with Me
         sr:
           batch_checkbox: Check to batch edit, delete or add to a collection.
-          collections_batch_checkbox: Check to batch delete collections. 
+          collections_batch_checkbox: Check to batch delete collections.
           check_all_label: Select all files to be added to a collection or edited
           detail_label: Display summary details of
           listing: Listing of items you have deposited in


### PR DESCRIPTION
# Story

This PR addresses https://github.com/scientist-softserv/utk-hyku/issues/62#issuecomment-1659011401

Ref:
- #62 

# Screenshots / Video

<details><summary>With a banner image uploaded</summary>

![image](https://github.com/scientist-softserv/utk-hyku/assets/19597776/0deef1ca-3340-422c-bbae-880b9ec84b03)

</details>

<details><summary>Without a banner image uploaded</summary>

![image](https://github.com/scientist-softserv/utk-hyku/assets/19597776/eb895988-11f0-4441-82da-67af1c818165)

</details>

# Notes

We are keeping all view options for now instead of just showing list/grid even though it was not in the wireframe because it was not explicitly said to be removed.  We chose not to follow the wireframes too literal in case it was not accounted for in the design.