### PR TITLE
fix adminset lookup for new works

### DIFF
--- a/app/controllers/concerns/hyrax/works_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/works_controller_behavior.rb
@@ -154,7 +154,7 @@ module Hyrax
       end
 
       def admin_set_id_for_new
-        Hyrax::AdminSetCreateService.find_or_create_default_admin_set.id.to_s
+        AdminSet.first.id.to_s
       end
 
       def build_form

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -214,7 +214,7 @@ services:
     entrypoint: ["sh", "-c"]
     command:
       - >
-        bundle && solrcloud-upload-configset.sh /app/samvera/hyrax-webapp/solr/conf &&
+        solrcloud-upload-configset.sh /app/samvera/hyrax-webapp/solr/conf &&
         solrcloud-assign-configset.sh &&
         SOLR_COLLECTION_NAME=hydra-test solrcloud-assign-configset.sh &&
         db-migrate-seed.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -214,7 +214,7 @@ services:
     entrypoint: ["sh", "-c"]
     command:
       - >
-        solrcloud-upload-configset.sh /app/samvera/hyrax-webapp/solr/conf &&
+        bundle && solrcloud-upload-configset.sh /app/samvera/hyrax-webapp/solr/conf &&
         solrcloud-assign-configset.sh &&
         SOLR_COLLECTION_NAME=hydra-test solrcloud-assign-configset.sh &&
         db-migrate-seed.sh


### PR DESCRIPTION
Calling `Hyrax::AdminSetCreateService.find_or_create_default_admin_set.id.to_s` calls the Wings reflections processor in `Wings::AttributeTransformer`. This in turn loads every member work of the AdminSet to get its ids. That's a long way to go just to get 'admin_set/default' each and very single time.
