### PR TITLE
update-staging-db-name-to-actual

### DIFF
--- a/ops/staging-deploy.tmpl.yaml
+++ b/ops/staging-deploy.tmpl.yaml
@@ -95,7 +95,7 @@ extraEnvVars: &envVars
   - name: DB_HOST
     value: pg-postgresql.staging-postgres.svc.cluster.local
   - name: DB_NAME
-    value: utk-hyku
+    value: utk-hyku-staging-hyrax
   - name: DB_PASSWORD
     value: $DB_PASSWORD
   - name: DB_URL


### PR DESCRIPTION
### # Story
I scaled utk-hyku staging down to 0 since we werent actively developing on their application (or so I thought). Rob asked me to spin it back up, which I did. But the web container would fail due to migration errors. After reviewing the deploy everything was setup to have the db_name=utk-hyku-staging-hyrax, so I update the deploy with that value and it came back up and all the data is there as it was. I am guessing this was added on the server and the code change just needed to get persisted in the values file.

Refs #issuenumber

# Expected Behavior Before Changes
When you scale up or re-deploy the db connection would fail.

# Expected Behavior After Changes
When you scale up or redeploy the actual db name is persisted and the web container is able to come up without any database issues with connection.

# Screenshots / Video

<details>
<summary></summary>

</details>

# Notes