### PR TITLE
Reverts Lint step for pipeline

### DIFF
--- a/.github/workflows/build-test-lint.yaml
+++ b/.github/workflows/build-test-lint.yaml
@@ -31,7 +31,7 @@ jobs:
       workerTarget: hyku-worker
   lint:
     needs: build
-    uses: scientist-softserv/actions/.github/workflows/lint.yaml@v0.0.15
+    uses: scientist-softserv/actions/.github/workflows/lint.yaml@v0.0.13
     with:
       webTarget: hyku-base
       workerTarget: hyku-worker

--- a/.github/workflows/build-test-lint.yaml
+++ b/.github/workflows/build-test-lint.yaml
@@ -33,5 +33,4 @@ jobs:
     needs: build
     uses: scientist-softserv/actions/.github/workflows/lint.yaml@v0.0.13
     with:
-      webTarget: hyku-base
-      workerTarget: hyku-worker
+      worker: true

--- a/.github/workflows/build-test-lint.yaml
+++ b/.github/workflows/build-test-lint.yaml
@@ -31,7 +31,7 @@ jobs:
       workerTarget: hyku-worker
   lint:
     needs: build
-    uses: scientist-softserv/actions/.github/workflows/lint.yaml@v0.0.14
+    uses: scientist-softserv/actions/.github/workflows/lint.yaml@v0.0.15
     with:
       webTarget: hyku-base
       workerTarget: hyku-worker


### PR DESCRIPTION
ref slack [convo](https://assaydepot.slack.com/archives/C0313NK5NMA/p1700663648605119)

Lint step fails on a solr error since October.

Since this is low priority it may be worth understanding what changed in v.14 and why they don't work, when we have time. 

This solution is more of a hot fix just to get the pipeline passing, to make it more trustworthy again while we develop. 

ref: 
- https://github.com/scientist-softserv/utk-hyku/issues/562