### PR TITLE
🧹 Bumping IIIF Print version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -134,7 +134,7 @@ GIT
 
 GIT
   remote: https://github.com/scientist-softserv/iiif_print.git
-  revision: e42cfd2a6d9b0aac9901084625ee1e1a0a3ccb6d
+  revision: 475453717d52628413bbfd8c2116db288457c870
   branch: main
   specs:
     iiif_print (1.0.0)
@@ -142,7 +142,6 @@ GIT
       derivative-rodeo (~> 0.5)
       hyrax (>= 2.5, < 6)
       nokogiri (>= 1.13.2)
-      rails (>= 5.0, < 8.0)
       rdf-vocab (~> 3.0)
 
 GIT


### PR DESCRIPTION
Refs: 
- https://github.com/scientist-softserv/utk-hyku/issues/556

This includes the following changes:

```
* 374fd5d — 🧹 Appease Rubocop Jeremy Friesen, (2023-11-27) (origin/experimenting-with-iiif-print-speed-ups)
* 573a38a — ⚙️ Commit Gemfile.lock Jeremy Friesen, (2023-11-27)
* a57c3c3 — ⚙️ Remove hard-dependency on Rails Jeremy Friesen, (2023-11-27)
* 81b569e — Report errors and ensure file exists LaRita Robinson, (2023-11-21)
* 3a9785f — 🧹 Fix broken specs Jeremy Friesen, (2023-11-20)
```