### PR TITLE
⚙️ Bump Bulkrax version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem 'blacklight', '~> 6.7'
 gem 'blacklight_oai_provider', '~> 6.1', '>= 6.1.1'
 gem 'bolognese', '>= 1.9.10'
 gem 'bootstrap-datepicker-rails'
-gem 'bulkrax', git: 'https://github.com/samvera-labs/bulkrax.git', ref: '817e4bb'
+gem 'bulkrax', '~> 5.4'
 gem 'byebug', group: %i[development test]
 gem 'capybara', group: %i[test]
 gem 'capybara-screenshot', '~> 1.0', group: %i[test]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,27 +18,6 @@ GIT
       webpacker
 
 GIT
-  remote: https://github.com/samvera-labs/bulkrax.git
-  revision: 817e4bb826260c2b402f730e7696dd90027f0c0c
-  ref: 817e4bb
-  specs:
-    bulkrax (5.2.1)
-      bagit (~> 0.4)
-      coderay
-      dry-monads (~> 1.4.0)
-      iso8601 (~> 0.9.0)
-      kaminari
-      language_list (~> 1.2, >= 1.2.1)
-      libxml-ruby (~> 3.2.4)
-      loofah (>= 2.2.3)
-      oai (>= 0.4, < 2.x)
-      rack (>= 2.0.6)
-      rails (>= 5.1.6)
-      rdf (>= 2.0.2, < 4.0)
-      rubyzip
-      simple_form
-
-GIT
   remote: https://github.com/samvera-labs/hyrax-doi.git
   revision: d494a50ef8ce3eae594c7ed7148c33b3c977d4a7
   branch: main
@@ -265,7 +244,7 @@ GEM
     babel-transpiler (0.7.0)
       babel-source (>= 4.0, < 6)
       execjs (~> 2.0)
-    bagit (0.4.5)
+    bagit (0.4.6)
       docopt (~> 0.5.0)
       validatable (~> 1.6)
     bcp47 (0.3.3)
@@ -353,6 +332,21 @@ GEM
       signet (~> 0.8)
       typhoeus
     builder (3.2.4)
+    bulkrax (5.4.1)
+      bagit (~> 0.4)
+      coderay
+      dry-monads (~> 1.4.0)
+      iso8601 (~> 0.9.0)
+      kaminari
+      language_list (~> 1.2, >= 1.2.1)
+      libxml-ruby (~> 3.2.4)
+      loofah (>= 2.2.3)
+      oai (>= 0.4, < 2.x)
+      rack (>= 2.0.6)
+      rails (>= 5.1.6)
+      rdf (>= 2.0.2, < 4.0)
+      rubyzip
+      simple_form
     byebug (11.1.3)
     cancancan (1.17.0)
     capybara (3.37.1)
@@ -1398,7 +1392,7 @@ DEPENDENCIES
   blacklight_oai_provider (~> 6.1, >= 6.1.1)
   bolognese (>= 1.9.10)
   bootstrap-datepicker-rails
-  bulkrax!
+  bulkrax (~> 5.4)
   byebug
   capybara
   capybara-screenshot (~> 1.0)


### PR DESCRIPTION
We're seeing issues with staging indices; namely we're attempting to
generate already exising indices.  By bumping we take advantage of the
resolution of https://github.com/samvera-labs/bulkrax/issues/862

The problem existed in 817e4bb826260c2b402f730e7696dd90027f0c0c but was
resolved in 1fc65e405dee38cba8b363b0837df28f2ef6518d.