### PR TITLE
🧹 Pin to json-canonicalization 0.3.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,8 @@ gem 'iiif_manifest', git: 'https://github.com/samvera/iiif_manifest.git', ref: '
 gem 'iiif_print', github: 'scientist-softserv/iiif_print', branch: 'main'
 gem 'jbuilder', '~> 2.5'
 gem 'jquery-rails' # Use jquery as the JavaScript library
+# The maintainers yanked 0.3.2 version (see https://github.com/dryruby/json-canonicalization/issues/2)
+gem 'json-canonicalization', "0.3.1"
 gem 'launchy', group: %i[test]
 gem 'listen', '>= 3.0.5', '< 3.2', group: %i[development]
 gem 'lograge'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -687,7 +687,7 @@ GEM
     jquery-ui-rails (6.0.1)
       railties (>= 3.2.16)
     json (2.6.2)
-    json-canonicalization (0.3.0)
+    json-canonicalization (0.3.1)
     json-jwt (1.15.3)
       activesupport (>= 4.2)
       aes_key_wrap
@@ -1421,6 +1421,7 @@ DEPENDENCIES
   iiif_print!
   jbuilder (~> 2.5)
   jquery-rails
+  json-canonicalization (= 0.3.1)
   launchy
   listen (>= 3.0.5, < 3.2)
   lograge


### PR DESCRIPTION
The maintainers yanked 0.3.2 version; so we're falling back to 0.3.1.

Related to:

- https://github.com/dryruby/json-canonicalization/issues/2
- https://github.com/scientist-softserv/palni-palci/pull/918

