### PR TITLE
🐛 Hide table that doesn't display anything

### DIFF
--- a/app/assets/stylesheets/hyku.scss
+++ b/app/assets/stylesheets/hyku.scss
@@ -482,3 +482,10 @@ body.public-facing {
 .mt-20 {
   margin-top: 20px;
 }
+
+// Making this very specific so it doesn't affect other tables.  This doesn't
+// appear to be actually displaying anything but it throws off the layout in
+// the dashboard on mobile, so we're hiding it
+body.dashboard #content-wrapper table[aria-label="Resource Types"].table.table-striped.sr-only.text-left {
+  display: none;
+}

--- a/app/assets/stylesheets/themes/dc_repository.scss
+++ b/app/assets/stylesheets/themes/dc_repository.scss
@@ -957,7 +957,6 @@ body.dc_repository {
         .abstract-search-results {
           p {
             padding-right: $golden-ratio-2;
-            text-align: justify;
             font-size: $type-3;
             line-height: $type-4;
           }


### PR DESCRIPTION
This table seems to not display anything but it takes up space and makes the page scroll horizontally on the dashboard.  We're very specifically targeting the table and hiding it.

The words looked a little too awkward when they were justified.  This commit will remove that from the catalog search page on the DC view theme.

# Story

Ref:
  - https://github.com/scientist-softserv/utk-hyku/issues/485
  - https://github.com/scientist-softserv/utk-hyku/issues/478

# Expected Behavior Before Changes

There was horizontal scrolling on the dashboard page in mobile widths.
The text on the catalog search results page was justified in mobile widths.

# Expected Behavior After Changes

A none displaying table is set to `display: none;` on the dashboard to prevent horizontal scrolling.
The is no longer justify aligned on the catalog search results page on mobile widths.

# Screenshots / Video

![horizontal-scroll](https://github.com/scientist-softserv/utk-hyku/assets/19597776/130cb127-03e6-4aa9-94f9-d366aa56d076)

Before
<img width="354" alt="image" src="https://github.com/scientist-softserv/utk-hyku/assets/19597776/45f36365-bdb1-4635-a4a1-4e6b7e8d28b1">

After
<img width="352" alt="image" src="https://github.com/scientist-softserv/utk-hyku/assets/19597776/3eaa6d6b-19e7-4a3c-89e7-e4428516cbe0">
