### PR TITLE
🧹 Remove a rogue `'`

### DIFF
--- a/app/views/hyrax/admin/users/index.html.erb
+++ b/app/views/hyrax/admin/users/index.html.erb
@@ -14,7 +14,7 @@
         <%= f.hint :email %>
         <%= f.label :email, class: "control-label", required: false %>
         <%= f.input_field :email, class: "form-control", value: "" %>
-        <%= f.input :roles, required: false %>'
+        <%= f.input :roles, required: false %>
         <%= f.submit t('.add'), class: 'btn btn-primary' %>
       </div>
     <% end %>


### PR DESCRIPTION
# Story

This commit will remove a rogue `'` from the admin users index page.

Ref:
  - ttps://github.com/scientist-softserv/utk-hyku/issues/595

# Screenshots / Video

<details>
<summary>Before</summary>

![Image](https://github.com/scientist-softserv/utk-hyku/assets/84697174/9d6dff7c-f52a-4328-91dd-b2bc4476a073)
</details>

<details>
<summary>After</summary>

<img width="1206" alt="image" src="https://github.com/scientist-softserv/utk-hyku/assets/19597776/58419f58-8c49-48d1-8ccf-ef90402c33f1">
</details>
