### PR TITLE
Install blacklight range limit

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem 'apartment'
 gem 'aws-sdk-sqs', group: %i[aws]
 gem 'blacklight', '~> 6.7'
 gem 'blacklight_oai_provider', '~> 6.1', '>= 6.1.1'
+gem 'blacklight_range_limit', '~> 7.0'
 gem 'bolognese', '>= 1.9.10'
 gem 'bootstrap-datepicker-rails'
 gem 'bulkrax', github: 'samvera/bulkrax', branch: 'main' # '~> 6.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -310,6 +310,11 @@ GEM
     blacklight_oai_provider (6.1.1)
       blacklight (~> 6.0)
       oai (~> 1.0)
+    blacklight_range_limit (7.0.1)
+      blacklight
+      jquery-rails
+      rails (>= 3.0)
+      tether-rails
     bolognese (1.9.17)
       activesupport (>= 4.2.5)
       benchmark_methods (~> 0.7)
@@ -1413,6 +1418,7 @@ DEPENDENCIES
   aws-sdk-sqs
   blacklight (~> 6.7)
   blacklight_oai_provider (~> 6.1, >= 6.1.1)
+  blacklight_range_limit (~> 7.0)
   bolognese (>= 1.9.10)
   bootstrap-datepicker-rails
   bulkrax!

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -50,3 +50,9 @@
 //= require statistics_tab_manager
 //= require blacklight_gallery/default
 //= require allinson_flex/application
+
+
+// For blacklight_range_limit built-in JS, if you don't want it you don't need
+// this:
+//= require 'blacklight_range_limit'
+

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -14,6 +14,9 @@
 //= require codemirror-autorefresh
 //= require codemirror/modes/css
 //= require jquery3
+//= require 'blacklight_range_limit'
+//= require range_limit_distro_facets
+//= require range_limit_slider
 //= require jquery_ujs
 //= require jquery.fontselect
 //= require dataTables/jquery.dataTables
@@ -50,9 +53,3 @@
 //= require statistics_tab_manager
 //= require blacklight_gallery/default
 //= require allinson_flex/application
-
-
-// For blacklight_range_limit built-in JS, if you don't want it you don't need
-// this:
-//= require 'blacklight_range_limit'
-

--- a/app/assets/javascripts/range_limit_distro_facets.js
+++ b/app/assets/javascripts/range_limit_distro_facets.js
@@ -1,0 +1,297 @@
+/* A custom event "plotDrawn.blacklight.rangeLimit" will be sent when flot plot
+   is (re-)drawn on screen possibly with a new size. target of event will be the DOM element
+   containing the plot.  Used to resize slider to match. */
+
+$(document).on('turbolinks:load', function() {
+  // ratio of width to height for desired display, multiply width by this ratio
+  // to get height. hard-coded in for now.
+  var display_ratio = 1/(1.618 * 2); // half a golden rectangle, why not
+  var redrawnEvent = "plotDrawn.blacklight.rangeLimit";
+
+
+
+    // Facets already on the page? Turn em into a chart.
+    $(".range_limit .profile .distribution.chart_js ul").each(function() {
+        turnIntoPlot($(this).parent());
+    });
+
+
+    // Add AJAX fetched range facets if needed, and add a chart to em
+    $(".range_limit .profile .distribution a.load_distribution").each(function() {
+        var container = $(this).parent('div.distribution');
+
+        $(container).load($(this).attr('href'), function(response, status) {
+            if ($(container).hasClass("chart_js") && status == "success" ) {
+              turnIntoPlot(container);
+            }
+        });
+    });
+
+    // Listen for twitter bootstrap collapsible open events, to render flot
+    // in previously hidden divs on open, if needed.
+    $("body").on("show.bs.collapse", function(event) {
+      // Was the target a .facet-content including a .chart-js?
+      var container =  $(event.target).filter(".facet-content").find(".chart_js");
+
+      // only if it doesn't already have a canvas, it isn't already drawn
+      if (container && container.find("canvas").length == 0) {
+        // be willing to wait up to 1100ms for container to
+        // have width -- right away on show.bs is too soon, but
+        // shown.bs is later than we want, we want to start rendering
+        // while animation is still in progress.
+        turnIntoPlot(container, 1100);
+      }
+    });
+
+
+
+    // after a collapsible facet contents is fully shown,
+    // resize the flot chart to current conditions. This way, if you change
+    // browser window size, you can get chart resized to fit by closing and opening
+    // again, if needed.
+
+    function redrawPlot(container) {
+      if (container && container.width() > 0) {
+        // resize the container's height, since width may have changed.
+        container.height( container.width() * display_ratio  );
+
+        // redraw the chart.
+        var plot = container.data("plot");
+        if (plot) {
+          // how to redraw after possible resize?
+          // Cribbed from https://github.com/flot/flot/blob/master/jquery.flot.resize.js
+          plot.resize();
+          plot.setupGrid();
+          plot.draw();
+          // plus trigger redraw of the selection, which otherwise ain't always right
+          // we'll trigger a fake event on one of the boxes
+          var form = $(container).closest(".limit_content").find("form.range_limit");
+          form.find("input.range_begin").trigger("change");
+
+          // send our custom event to trigger redraw of slider
+          $(container).trigger(redrawnEvent);
+        }
+      }
+    }
+
+    $("body").on("shown.bs.collapse", function(event) {
+      var container =  $(event.target).filter(".facet-content").find(".chart_js");
+      redrawPlot(container);
+    });
+
+    // debouce borrowed from underscore
+    // Returns a function, that, as long as it continues to be invoked, will not
+    // be triggered. The function will be called after it stops being called for
+    // N milliseconds. If `immediate` is passed, trigger the function on the
+    // leading edge, instead of the trailing.
+    debounce = function(func, wait, immediate) {
+      var timeout;
+      return function() {
+        var context = this, args = arguments;
+        var later = function() {
+          timeout = null;
+          if (!immediate) func.apply(context, args);
+        };
+        var callNow = immediate && !timeout;
+        clearTimeout(timeout);
+        timeout = setTimeout(later, wait);
+        if (callNow) func.apply(context, args);
+      };
+    };
+
+    $(window).on("resize", debounce(function() {
+      $(".chart_js").each(function(i, container) {
+        redrawPlot($(container));
+      });
+    }, 350));
+
+    // second arg, if provided, is a number of ms we're willing to
+    // wait for the container to have width before giving up -- we'll
+    // set 50ms timers to check back until timeout is expired or the
+    // container is finally visible. The timeout is used when we catch
+    // bootstrap show event, but the animation hasn't barely begun yet -- but
+    // we don't want to wait until it's finished, we want to start rendering
+    // as soon as we can.
+    //
+    // We also will
+    function turnIntoPlot(container, wait_for_visible) {
+      // flot can only render in a a div with a defined width.
+      // for instance, a hidden div can't generally be rendered in (although if you set
+      // an explicit width on it, it might work)
+      //
+      // We'll count on later code that catch bootstrap collapse open to render
+      // on show, for currently hidden divs.
+
+      // for some reason width sometimes return negative, not sure
+      // why but it's some kind of hidden.
+      if (container.width() > 0) {
+        var height = container.width() * display_ratio;
+
+        // Need an explicit height to make flot happy.
+        container.height( height )
+
+        areaChart($(container));
+
+        $(container).trigger(redrawnEvent);
+      }
+      else if (wait_for_visible > 0) {
+        setTimeout(function() {
+          turnIntoPlot(container, wait_for_visible - 50);
+        }, 50);
+      }
+    }
+
+       // Takes a div holding a ul of distribution segments produced by
+      // blacklight_range_limit/_range_facets and makes it into
+      // a flot area chart.
+      function areaChart(container) {
+        //flot loaded? And canvas element supported.
+        if (  domDependenciesMet()  ) {
+
+          // Grab the data from the ul div
+          var series_data = new Array();
+          var pointer_lookup = new Array();
+          var x_ticks = new Array();
+          var min = BlacklightRangeLimit.parseNum($(container).find("ul li:first-child span.from").text());
+          var max = BlacklightRangeLimit.parseNum($(container).find("ul li:last-child span.to").text());
+
+          $(container).find("ul li").each(function() {
+              var from = BlacklightRangeLimit.parseNum($(this).find("span.from").text());
+              var to = BlacklightRangeLimit.parseNum($(this).find("span.to").text());
+              var count = BlacklightRangeLimit.parseNum($(this).find("span.count").text());
+              var avg = (count / (to - from + 1));
+
+
+              //We use the avg as the y-coord, to make the area of each
+              //segment proportional to how many documents it holds.
+              series_data.push( [from, avg ] );
+              series_data.push( [to+1, avg] );
+
+              x_ticks.push(from);
+
+              pointer_lookup.push({'from': from, 'to': to, 'count': count, 'label': $(this).find(".facet_select").text() });
+          });
+          var max_plus_one = BlacklightRangeLimit.parseNum($(container).find("ul li:last-child span.to").text())+1;
+          x_ticks.push( max_plus_one );
+
+
+
+          var plot;
+          var config = $(container).closest('.facet_limit').data('plot-config') || {};
+
+          try {
+            plot = $.plot($(container), [series_data],
+                $.extend(true, config, {
+                yaxis: {  ticks: [], min: 0, autoscaleMargin: 0.1},
+              //xaxis: { ticks: x_ticks },
+              xaxis: { tickDecimals: 0 }, // force integer ticks
+              series: { lines: { fill: true, steps: true }},
+              grid: {clickable: true, hoverable: true, autoHighlight: false},
+              selection: {mode: "x"}
+            }));
+          }
+          catch(err) {
+            alert(err);
+          }
+
+          find_segment_for = function_for_find_segment(pointer_lookup);
+          var last_segment = null;
+          $(container).tooltip({'placement': 'bottom', 'trigger': 'manual', 'delay': { show: 0, hide: 100}});
+
+          $(container).bind("plothover", function (event, pos, item) {
+            segment = find_segment_for(pos.x);
+
+            if(segment != last_segment) {
+              var title = find_segment_for(pos.x).label  + ' (' + BlacklightRangeLimit.parseNum(segment.count) + ')';
+              $(container).attr("title", title).tooltip("_fixTitle").tooltip("show");
+
+              last_segment  = segment;
+             }
+          });
+
+          $(container).bind("mouseout", function() {
+            last_segment = null;
+            $(container).tooltip('hide');
+          });
+          $(container).bind("plotclick", function (event, pos, item) {
+              if ( plot.getSelection() == null) {
+                segment = find_segment_for(pos.x);
+                plot.setSelection( normalized_selection(segment.from, segment.to));
+              }
+          });
+          $(container).bind("plotselected plotselecting", function(event, ranges) {
+              if (ranges != null ) {
+                var from = Math.floor(ranges.xaxis.from);
+                var to = Math.floor(ranges.xaxis.to);
+
+                var form = $(container).closest(".limit_content").find("form.range_limit");
+                form.find("input.range_begin").val(from);
+                form.find("input.range_end").val(to);
+
+                var slider_placeholder = $(container).closest(".limit_content").find("[data-slider-placeholder]");
+                if (slider_placeholder) {
+                  slider_placeholder.slider("setValue", [from, to]);
+                }
+              }
+          });
+
+          var form = $(container).closest(".limit_content").find("form.range_limit");
+          form.find("input.range_begin, input.range_end").on('input', function () {
+            plot.setSelection( form_selection(form, min, max), true );
+          });
+          $(container).closest(".limit_content").find(".profile .range").on("slide", function(event, ui) {
+            var values = $(event.target).data("slider").getValue();
+            form.find("input.range_begin").val(values[0]);
+            form.find("input.range_end").val(values[1]);
+            plot.setSelection( normalized_selection(values[0], Math.max(values[0], values[1])), true);
+          });
+
+          // initially entirely selected, to match slider
+          plot.setSelection(normalized_selection(min, max));
+        }
+      }
+
+
+      // Send endpoint to endpoint+0.99999 to have display
+      // more closely approximate limiting behavior esp
+      // at small resolutions. (Since we search on whole numbers,
+      // inclusive, but flot chart is decimal.)
+      function normalized_selection(min, max) {
+        max += 0.99999;
+
+        return {xaxis: { 'from':min, 'to':max}}
+      }
+
+      function form_selection(form, min, max) {
+        var begin_val = BlacklightRangeLimit.parseNum($(form).find("input.range_begin").val());
+        if (isNaN(begin_val) || begin_val < min) {
+          begin_val = min;
+        }
+        var end_val = BlacklightRangeLimit.parseNum($(form).find("input.range_end").val());
+        if (isNaN(end_val) || end_val > max) {
+          end_val = max;
+        }
+
+        return normalized_selection(begin_val, end_val);
+      }
+
+      function function_for_find_segment(pointer_lookup_arr) {
+        return function(x_coord) {
+          for (var i = pointer_lookup_arr.length-1 ; i >= 0 ; i--) {
+            var hash = pointer_lookup_arr[i];
+            if (x_coord >= hash.from)
+              return hash;
+          }
+          return pointer_lookup_arr[0];
+        };
+      }
+
+      // Check if Flot is loaded, and if browser has support for
+      // canvas object, either natively or via IE excanvas.
+      function domDependenciesMet() {
+        var flotLoaded = (typeof $.plot != "undefined");
+        var canvasAvailable = ((typeof(document.createElement('canvas').getContext) != "undefined") || (typeof  window.CanvasRenderingContext2D != 'undefined' || typeof G_vmlCanvasManager != 'undefined'));
+
+        return (flotLoaded && canvasAvailable);
+      }
+});

--- a/app/assets/javascripts/range_limit_slider.js
+++ b/app/assets/javascripts/range_limit_slider.js
@@ -1,0 +1,148 @@
+// for Blacklight.onLoad:
+
+$(document).on('turbolinks:load', function() {
+  $(".range_limit .profile .range.slider_js").each(function() {
+     var range_element = $(this);
+
+     var boundaries = min_max(this);
+     var min = boundaries[0];
+     var max = boundaries[1];
+
+     if (isInt(min) && isInt(max)) {
+       $(this).contents().wrapAll('<div style="display:none" />');
+
+       var range_element = $(this);
+       var form = $(range_element).closest(".range_limit").find("form.range_limit");
+       var begin_el = form.find("input.range_begin");
+       var end_el = form.find("input.range_end");
+
+       var placeholder_input = $('<input type="text" data-slider-placeholder="true" style="width:100%;">').appendTo(range_element);
+
+       // make sure slider is loaded
+       if (placeholder_input.slider !== undefined) {
+        placeholder_input.slider({
+          min: min,
+          max: max,
+          value: [min, max],
+          tooltip: "hide"
+        });
+
+        // try to make slider width/orientation match chart's
+        var container      = range_element.closest(".range_limit");
+        var plot           = container.find(".chart_js").data("plot");
+        var slider_el      = container.find(".slider");
+
+        if (plot && slider_el) {
+          slider_el.width(plot.width());
+          slider_el.css("display", "block")
+          slider_el.css('margin-right', 'auto');
+          slider_el.css('margin-left', 'auto');
+        }
+        else if (slider_el) {
+          slider_el.css("width", "100%");
+        }
+       }
+
+       // Slider change should update text input values.
+       var parent = $(this).parent();
+       var form = $(parent).closest(".limit_content").find("form.range_limit");
+       $(parent).closest(".limit_content").find(".profile .range").on("slide", function(event, ui) {
+        var values = $(event.target).data("slider").getValue();
+        form.find("input.range_begin").val(values[0]);
+        form.find("input.range_end").val(values[1]);
+       });
+     }
+
+    begin_el.val(min);
+    end_el.val(max);
+
+    begin_el.on('input', function() {
+      var val = BlacklightRangeLimit.parseNum($(this).val());
+      if ( isNaN(val)  || val < min) {
+        //for weird data, set slider at min
+        val = min;
+      }
+      var values = placeholder_input.data("slider").getValue();
+      values[0] = val;
+      placeholder_input.slider("setValue", values);
+    });
+
+    end_el.on('inout', function() {
+       var val = BlacklightRangeLimit.parseNum($(this).val());
+       if ( isNaN(val) || val > max ) {
+         //weird entry, set slider to max
+         val = max;
+       }
+      var values = placeholder_input.data("slider").getValue();
+      values[1] = val;
+      placeholder_input.slider("setValue", values);
+    });
+
+    begin_el.change(function() {
+      var val1 = BlacklightRangeLimit.parseNum(begin_el.val());
+      var val2 = BlacklightRangeLimit.parseNum(end_el.val());
+
+      if (val2 < val1) {
+        begin_el.val(val2);
+        end_el.val(val1);
+      }
+    });
+
+    end_el.change(function() {
+      var val1 = BlacklightRangeLimit.parseNum(begin_el.val());
+      var val2 = BlacklightRangeLimit.parseNum(end_el.val());
+
+      if (val2 < val1) {
+        begin_el.val(val2);
+        end_el.val(val1);
+      }
+    });
+
+  });
+
+  // catch event for redrawing chart, to redraw slider to match width
+  $("body").on("plotDrawn.blacklight.rangeLimit", function(event) {
+    var area       = $(event.target).closest(".limit_content.range_limit");
+    var plot       = area.find(".chart_js").data("plot");
+    var slider_el  = area.find(".slider");
+
+    if (plot && slider_el) {
+        slider_el.width(plot.width());
+        slider_el.css("display", "block")
+        slider_el.css('margin-right', 'auto');
+        slider_el.css('margin-left', 'auto');
+    }
+  });
+
+  // returns two element array min/max as numbers. If there is a limit applied,
+  // it's boundaries are are limits. Otherwise, min/max in current result
+  // set as sniffed from HTML. Pass in a DOM element for a div.range
+  // Will return NaN as min or max in case of error or other weirdness.
+  function min_max(range_element) {
+     var current_limit =  $(range_element).closest(".limit_content.range_limit").find(".current")
+
+
+
+     var min = max = BlacklightRangeLimit.parseNum(current_limit.find(".single").text())
+     if ( isNaN(min)) {
+       min = BlacklightRangeLimit.parseNum(current_limit.find(".from").first().text());
+       max = BlacklightRangeLimit.parseNum(current_limit.find(".to").first().text());
+     }
+
+     if (isNaN(min) || isNaN(max)) {
+        //no current limit, take from results min max included in spans
+        min = BlacklightRangeLimit.parseNum($(range_element).find(".min").first().text());
+        max = BlacklightRangeLimit.parseNum($(range_element).find(".max").first().text());
+     }
+
+     return [min, max]
+  }
+
+
+  // Check to see if a value is an Integer
+  // see: http://stackoverflow.com/questions/3885817/how-to-check-if-a-number-is-float-or-integer
+  function isInt(n) {
+    return n % 1 === 0;
+  }
+
+  });

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -21,4 +21,9 @@
  *= require utk-overrides
  *= require allinson_flex/application
  *= require_self
- */
+ 
+ *
+ * Used by blacklight_range_limit
+ *= require  'blacklight_range_limit'
+ *
+*/

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class CatalogController < ApplicationController
-
   include BlacklightRangeLimit::ControllerOverride
   include Hydra::Catalog
   include Hydra::Controller::ControllerBehavior
@@ -79,8 +78,8 @@ class CatalogController < ApplicationController
     config.add_facet_field 'date_created_sim', label: "Date Created",
                                                range: {
                                                  num_segments: 6,
-                                                 assumed_boundaries: [1100, Time.now.year + 2],
-                                                 segments: false,
+                                                 assumed_boundaries: [1100, Time.zone.now.year + 2],
+                                                 segments: true,
                                                  maxlength: 4
                                                }
     config.add_facet_field 'human_readable_type_sim', label: "Type", limit: 5

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -76,6 +76,13 @@ class CatalogController < ApplicationController
 
     # solr fields that will be treated as facets by the blacklight application
     #   The ordering of the field names is the order of the display
+    config.add_facet_field 'date_created_sim', label: "Date Created",
+                                               range: {
+                                                 num_segments: 6,
+                                                 assumed_boundaries: [1100, Time.now.year + 2],
+                                                 segments: false,
+                                                 maxlength: 4
+                                               }
     config.add_facet_field 'human_readable_type_sim', label: "Type", limit: 5
     config.add_facet_field 'resource_type_sim', label: "Resource Type", limit: 5
     config.add_facet_field 'creator_sim', limit: 5

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class CatalogController < ApplicationController
+
+  include BlacklightRangeLimit::ControllerOverride
   include Hydra::Catalog
   include Hydra::Controller::ControllerBehavior
   include BlacklightOaiProvider::Controller

--- a/app/controllers/search_history_controller.rb
+++ b/app/controllers/search_history_controller.rb
@@ -1,0 +1,6 @@
+class SearchHistoryController < ApplicationController
+  include Blacklight::SearchHistory
+
+  helper BlacklightRangeLimit::ViewHelperOverride
+  helper RangeLimitHelper
+end

--- a/app/controllers/search_history_controller.rb
+++ b/app/controllers/search_history_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class SearchHistoryController < ApplicationController
   include Blacklight::SearchHistory
 

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -2,6 +2,8 @@
 
 class SearchBuilder < Blacklight::SearchBuilder
   include Blacklight::Solr::SearchBuilderBehavior
+  include BlacklightRangeLimit::RangeLimitBuilder
+
   include Hydra::AccessControlsEnforcement
   include Hyrax::SearchFilters
 end

--- a/app/views/blacklight_range_limit/_range_limit_panel.html.erb
+++ b/app/views/blacklight_range_limit/_range_limit_panel.html.erb
@@ -1,0 +1,89 @@
+<%#
+  OVERRIDE blacklight_range_limit 7.0.1 to remove the distribution when
+  there aren't any segments to display.
+%>
+
+<%- # requires solr_config local passed in
+  field_config = range_config(field_name)
+  label = facet_field_label(field_name)
+
+  input_label_range_begin = field_config[:input_label_range_begin] || t("blacklight.range_limit.range_begin", field_label: label)
+  input_label_range_end   = field_config[:input_label_range_end] || t("blacklight.range_limit.range_end", field_label: label)
+  maxlength = field_config[:maxlength]
+-%>
+
+<div class="limit_content range_limit">
+  <% if has_selected_range_limit?(field_name) %>
+    <ul class="current list-unstyled facet-values">
+      <li class="selected">
+        <span class="facet-label">
+          <span class="selected"><%= range_display(field_name) %></span>
+           <%= link_to remove_range_param(field_name), :class=>"remove", :title => t('blacklight.range_limit.remove_limit') do %>
+            <span class="glyphicon glyphicon-remove"></span>
+            <span class="sr-only">[<%= t('blacklight.range_limit.remove_limit') %>]</span>
+           <% end %>
+        </span>
+        <span class="selected facet-count"><%= number_with_delimiter(@response.total) %></span>
+      </li>
+    </ul>
+
+  <% end %>
+
+  <% unless selected_missing_for_range_limit?(field_name) %>
+    <%= form_tag search_action_path, :method => :get, class: [BlacklightRangeLimit.classes[:form], "range_#{field_name}"].join(' ') do %>
+      <%= render_hash_as_hidden_fields(search_state.params_for_search.except(:page)) %>
+
+      <!-- we need to include a dummy search_field parameter if none exists,
+           to trick blacklight into displaying actual search results instead
+           of home page. Not a great solution, but easiest for now. -->
+      <% unless params.has_key?(:search_field) %>
+        <%= hidden_field_tag("search_field", "dummy_range") %>
+      <% end %>
+
+      <%= render_range_input(field_name, :begin, input_label_range_begin, maxlength) %> – <%= render_range_input(field_name, :end, input_label_range_end, maxlength) %>
+      <%= submit_tag t('blacklight.range_limit.submit_limit'), class: BlacklightRangeLimit.classes[:submit] %>
+    <% end %>
+  <% end %>
+
+  <!-- no results profile if missing is selected -->
+  <% unless selected_missing_for_range_limit?(field_name) %>
+    <!-- you can hide this if you want, but it has to be on page if you want
+         JS slider and calculated facets to show up, JS sniffs it. -->
+    <div class="profile">
+        <% if stats_for_field?(field_name) %>
+          <!-- No stats information found for field  in search response -->
+        <% end %>
+
+        <% if (min = range_results_endpoint(field_name, :min)) &&
+              (max = range_results_endpoint(field_name, :max)) %>
+          <p class="range subsection <%= "slider_js" unless field_config[:slider_js] == false  %>">
+            Current results range from <span class="min"><%= range_results_endpoint(field_name, :min) %></span> to <span class="max"><%= range_results_endpoint(field_name, :max) %></span>
+          </p>
+
+          <% if field_config[:segments] != false && (solr_range_queries_to_a(field_name).length > 0) %>
+            <div class="distribution subsection <%= 'chart_js' unless field_config[:chart_js] == false %>">
+              <!-- if  we already fetched segments from solr, display them
+                   here. Otherwise, display a link to fetch them, which JS
+                   will AJAX fetch.  -->
+                 <%= render(:partial => "blacklight_range_limit/range_segments", :locals => {:solr_field => field_name}) %>
+            </div>
+          <% end %>
+        <% end %>
+
+
+
+        <% if (stats = stats_for_field(field_name)) && stats["missing"] > 0 %>
+          <ul class="missing list-unstyled facet-values subsection">
+            <li>
+              <span class="facet-label">
+                <%= link_to BlacklightRangeLimit.labels[:missing], add_range_missing(field_name) %>
+              </span>
+              <span class="facet-count">
+                <%= number_with_delimiter(stats["missing"]) %>
+              </span>
+            </li>
+          </ul>
+        <% end %>
+    </div>
+  <% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@
 # OVERRIDE Hyrax 2.9.0 to add featured collection routes
 
 Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
+  concern :range_searchable, BlacklightRangeLimit::Routes::RangeSearchable.new
   resources :identity_providers
   concern :iiif_search, BlacklightIiifSearch::Routes.new
   mount AllinsonFlex::Engine, at: '/'
@@ -81,6 +82,7 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
     concerns :oai_provider
 
     concerns :searchable
+    concerns :range_searchable
   end
 
   resources :solr_documents, only: [:show], path: '/catalog', controller: 'catalog' do


### PR DESCRIPTION
# Story

## 🚧 Update `Gemfile` and ran installer

be4dcaccd7efb94c84136d58463dac0e73abd026

install command:
```sh
rails generate blacklight_range_limit:install
```

## 🚧 Add facet to `CatalogController`

257eb66655a3f9a372c1f67e603daf1cdbe4537f

This commit will follow the documentation and add the facet to the
`CatalogController`.  In our case we have the `date_created_sim` field.

## 🎁 Add blacklight range limit gem

169579f430964fe32c7ad8fc46c8541647db9a30

This commit will finish adding the range limit gem to the application.
The slider and distro js wasn't loading in the gem because they keyed
off of Blacklight.onLoad and that doesn't occur before the scripts run.
I'm adding both js files into assets and changing the load to
`$(document).on('turbolinks:load', function()`.

Ref:
  - https://github.com/scientist-softserv/utk-hyku/issues/593

# Screenshots / Video
<img width="990" alt="image" src="https://github.com/scientist-softserv/utk-hyku/assets/19597776/1eb0a188-4bc9-4ea9-aeaa-86bc5ba7376b">
