### PR TITLE
🐛 Adjust z-index to show menu correctly

### DIFF
--- a/app/assets/stylesheets/themes/dc_show.scss
+++ b/app/assets/stylesheets/themes/dc_show.scss
@@ -178,6 +178,7 @@ body.dc_show {
     border-bottom: 0;
     margin-bottom: 25px;
     position: relative;
+    z-index: 3;
   }
 
   .dc-repository-show-elements-wrapper {


### PR DESCRIPTION
This commit will adjust the z-index of a parent element of the dropdown menu to show it in front of the other elements.  I couldn't just adjust the menu itself because so I had to go up levels until it took effect.

Ref:
  - https://github.com/scientist-softserv/utk-hyku/issues/478

# Screenshots / Video

<img width="567" alt="image" src="https://github.com/scientist-softserv/utk-hyku/assets/19597776/0d390ca6-d253-4b0e-9993-906946c08142">
