### PR TITLE
🎁 Switch from `all_text_tsimv` to `_tesimv`

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -26,11 +26,11 @@ class CatalogController < ApplicationController
 
   configure_blacklight do |config|
     # IiifPrint index fields
-    config.add_index_field 'all_text_tsimv', highlight: true, helper_method: :render_ocr_snippets
+    config.add_index_field 'all_text_tesimv', highlight: true, helper_method: :render_ocr_snippets
 
     # configuration for Blacklight IIIF Content Search
     config.iiif_search = {
-      full_text_field: 'all_text_tsimv',
+      full_text_field: 'all_text_tesimv',
       object_relation_field: 'is_page_of_ssim',
       supported_params: %w[q page],
       autocomplete_handler: 'iiif_suggest',
@@ -60,7 +60,7 @@ class CatalogController < ApplicationController
     config.default_solr_params = {
       qt: "search",
       rows: 10,
-      qf: "title_tesim description_tesim creator_tesim keyword_tesim all_text_timv"
+      qf: "title_tesim description_tesim creator_tesim keyword_tesim all_text_timv all_text_tesimv"
     }
 
     # Specify which field to use in the tag cloud on the homepage.

--- a/app/indexers/hyrax/file_set_indexer_decorator.rb
+++ b/app/indexers/hyrax/file_set_indexer_decorator.rb
@@ -7,6 +7,7 @@ module Hyrax
     def generate_solr_document
       super.tap do |solr_doc|
         solr_doc['rdf_type_ssim'] = object.parent_works.first.rdf_type if attachment?
+        solr_doc['all_text_tesimv'] = solr_doc['all_text_tsimv'] if solr_doc['all_text_tsimv'].present?
       end
     end
 


### PR DESCRIPTION
# Story

⚠️ Requires a reindex of all FileSet objects to take effect.

This commit will switch the all_text field from a `tsimv` to a `tesimv` field.  The *_te* fields are set up to be tokenized and stemmed.

Ref:
  - https://github.com/scientist-softserv/utk-hyku/issues/502

# Screenshots / Video

Searching for the word `person` will give you a hit for `persons`
<img width="1167" alt="Screenshot 2024-02-17 at 16 55 22" src="https://github.com/scientist-softserv/utk-hyku/assets/19597776/1e4468d3-93b6-4945-bb1e-bfc326ffd6d7">
