### PR TITLE
🎁 Aggregate creators from m3 profile and add roles

### DIFF
--- a/app/indexers/app_indexer.rb
+++ b/app/indexers/app_indexer.rb
@@ -12,6 +12,7 @@ class AppIndexer < Hyrax::WorkIndexer
   # Uncomment this block if you want to add custom indexing behavior:
   def generate_solr_document
     super.tap do |solr_doc|
+      solr_doc["creator_sim"] = all_creators
       solr_doc["account_cname_tesim"] = Site.instance&.account&.cname
       solr_doc["bulkrax_identifier_ssim"] = object.bulkrax_identifier
       # tesim is the wrong field for this, but until we reindex everything we need to keep it
@@ -19,4 +20,11 @@ class AppIndexer < Hyrax::WorkIndexer
       solr_doc[CatalogController.title_field] = object.title.first
     end
   end
+
+  private
+
+    def all_creators
+      props = SolrDocument.creator_fields
+      props.map { |prop| Array(object.try(prop)) }.flatten.compact
+    end
 end

--- a/app/models/solr_endpoint.rb
+++ b/app/models/solr_endpoint.rb
@@ -25,6 +25,7 @@ class SolrEndpoint < Endpoint
     ActiveFedora::SolrService.instance.conn = connection
     Blacklight.connection_config = connection_options
     Blacklight.default_index = nil
+    SolrDocument.field_semantics
   end
 
   # Remove the solr collection then destroy this record


### PR DESCRIPTION
# Story

⚠️ Change will take effect after a reindex of works and collections.

Since the SolrDocument loads on boot we need to trigger it when the tenant changes because the m3 profiles are tenant specific so I added `SolrDocument.field_semantics` to be triggered by `switch!`.  We also will aggregate all the creators from the m3 profile into the `creators` facet.

Ref:
  - https://github.com/scientist-softserv/utk-hyku/issues/105

# Screenshots / Video

I set the same name in 4 different properties
<img width="796" alt="image" src="https://github.com/scientist-softserv/utk-hyku/assets/19597776/4708e2fe-4fd9-4932-a6cc-d824a7f90ef7">

I should only see the name once
<img width="637" alt="image" src="https://github.com/scientist-softserv/utk-hyku/assets/19597776/c05954dc-3c3b-46df-874c-caa9f1058d82">
