### PR TITLE
Range limit adjustments

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -16,11 +16,7 @@
 //= require jquery3
 //= require jquery_ujs
 //= require jquery.fontselect
-//= require flot/jquery.flot.js
-//= require flot/jquery.flot.selection.js
-//= require bootstrap-slider
 //= require bootstrap/tooltip
-//= require_tree ./blacklight_range_limit
 //= require dataTables/jquery.dataTables
 //= require dataTables/bootstrap/3/jquery.dataTables.bootstrap
 //= require stat_slider
@@ -55,3 +51,13 @@
 //= require statistics_tab_manager
 //= require blacklight_gallery/default
 //= require allinson_flex/application
+
+// This is required for the Blacklight Range Limit gem v7.0.1
+//
+// We copied all the js over in the ./blacklight_range_limit because
+// In the gem, there is a `//= require 'jquery'` in the `blacklight_range_limit.js`
+// that double loads jquery which causes issues beacuse we are using jquery3 in this project.
+//= require flot/jquery.flot.js
+//= require flot/jquery.flot.selection.js
+//= require bootstrap-slider
+//= require_tree ./blacklight_range_limit

--- a/app/assets/javascripts/blacklight_range_limit/range_limit_distro_facets.js
+++ b/app/assets/javascripts/blacklight_range_limit/range_limit_distro_facets.js
@@ -1,12 +1,14 @@
+// for Blacklight.onLoad:
+
 /* A custom event "plotDrawn.blacklight.rangeLimit" will be sent when flot plot
    is (re-)drawn on screen possibly with a new size. target of event will be the DOM element
    containing the plot.  Used to resize slider to match. */
 
-$(document).on('turbolinks:load', function() {
-  // ratio of width to height for desired display, multiply width by this ratio
-  // to get height. hard-coded in for now.
-  var display_ratio = 1/(1.618 * 2); // half a golden rectangle, why not
-  var redrawnEvent = "plotDrawn.blacklight.rangeLimit";
+   Blacklight.onLoad(function() {
+    // ratio of width to height for desired display, multiply width by this ratio
+    // to get height. hard-coded in for now.
+    var display_ratio = 1/(1.618 * 2); // half a golden rectangle, why not
+    var redrawnEvent = "plotDrawn.blacklight.rangeLimit";
 
 
 
@@ -294,4 +296,4 @@ $(document).on('turbolinks:load', function() {
 
         return (flotLoaded && canvasAvailable);
       }
-});
+  });

--- a/app/assets/javascripts/blacklight_range_limit/range_limit_shared.js
+++ b/app/assets/javascripts/blacklight_range_limit/range_limit_shared.js
@@ -10,14 +10,14 @@
     this.options = options || {};
   }
 
-  BlacklightRangeLimit.noConflict = function noConflict() {
-    global.BlacklightRangeLimit = previousBlacklightRangeLimit;
-    return BlacklightRangeLimit;
-  };
-
   BlacklightRangeLimit.parseNum = function parseNum(str) {
     str = String(str).replace(/[^0-9]/g, '');
     return parseInt(str, 10);
+  };
+
+  BlacklightRangeLimit.noConflict = function noConflict() {
+    global.BlacklightRangeLimit = previousBlacklightRangeLimit;
+    return BlacklightRangeLimit;
   };
 
   global.BlacklightRangeLimit = BlacklightRangeLimit;

--- a/app/assets/javascripts/blacklight_range_limit/range_limit_slider.js
+++ b/app/assets/javascripts/blacklight_range_limit/range_limit_slider.js
@@ -1,6 +1,7 @@
 // for Blacklight.onLoad:
 
-$(document).on('turbolinks:load', function() {
+Blacklight.onLoad(function() {
+
   $(".range_limit .profile .range.slider_js").each(function() {
      var range_element = $(this);
 

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -75,13 +75,13 @@ class CatalogController < ApplicationController
 
     # solr fields that will be treated as facets by the blacklight application
     #   The ordering of the field names is the order of the display
-    config.add_facet_field 'date_created_sim', label: "Date Created",
-                                               range: {
-                                                 num_segments: 6,
-                                                 assumed_boundaries: [1100, Time.zone.now.year + 2],
-                                                 segments: true,
-                                                 maxlength: 4
-                                               }
+    config.add_facet_field 'date_created_d_sim', label: "Date Created",
+                                                 range: {
+                                                   num_segments: 6,
+                                                   assumed_boundaries: [1100, Time.zone.now.year + 2],
+                                                   segments: true,
+                                                   maxlength: 4
+                                                 }
     config.add_facet_field 'human_readable_type_sim', label: "Type", limit: 5
     config.add_facet_field 'resource_type_sim', label: "Resource Type", limit: 5
     config.add_facet_field 'creator_sim', limit: 5


### PR DESCRIPTION
[🐛 Fix JavaScript issues caused by double jquery](https://github.com/scientist-softserv/utk-hyku/commit/aa6cb1efea52ddfc1536f318034ecfdcefbc4cc2) 

This commit will copy over the exact implementation of the range limit
js files and move it to the bottom of the page.  We are doing this
because in v7.0.1 (which is the highest version we can upgrade to) there
is a require of jquery in their manifest.  This is causing a double
loading of jquery which then causes issues.

[🧹 Change date_created_sim to date_created_d_sim](https://github.com/scientist-softserv/utk-hyku/commit/889007af4856b3a162de53f1884f47d2982ef1ba) 

The date_created_d_sim field is more appropriate for date ranges because
it is the "Machine Readable Date Created" field.  This is perfect for
date ranges because it should be a specific format and can be sorted.

Ref:
  - #593 