### PR TITLE
🎁 Add URI to human readable string to collections

### DIFF
--- a/app/indexers/collection_indexer.rb
+++ b/app/indexers/collection_indexer.rb
@@ -4,13 +4,21 @@ class CollectionIndexer < Hyrax::CollectionIndexer
   # This indexes the default metadata. You can remove it if you want to
   # provide your own metadata and indexing.
   include Hyrax::IndexesBasicMetadata
+  include UriToStringBehavior
 
   # Uncomment this block if you want to add custom indexing behavior:
   def generate_solr_document
     super.tap do |solr_doc|
+      solr_doc["creator_tesim"] = all_creators
       solr_doc["bulkrax_identifier_sim"] = object.bulkrax_identifier
       solr_doc["account_cname_tesim"] = Site.instance&.account&.cname
       solr_doc[CatalogController.title_field] = object.title.first
     end
   end
+
+  private
+
+    def all_creators
+      SolrDocument.creator_fields.map { |prop| uri_to_value_for(object.try(prop)) }.flatten.compact
+    end
 end


### PR DESCRIPTION
This commit will add the UriToStringBehavior module to the collection indexer.

Ref:
  - https://github.com/scientist-softserv/utk-hyku/issues/592

<img width="851" alt="image" src="https://github.com/scientist-softserv/utk-hyku/assets/19597776/3a9e6e0d-e7c3-4e57-80cd-26c6a1519aae">

<img width="707" alt="image" src="https://github.com/scientist-softserv/utk-hyku/assets/19597776/41d48989-15e9-4b04-9234-9679322fce3f">
