### PR TITLE
🐛 Add uri to string creator to creator_sim also

### DIFF
--- a/app/indexers/collection_indexer.rb
+++ b/app/indexers/collection_indexer.rb
@@ -9,7 +9,7 @@ class CollectionIndexer < Hyrax::CollectionIndexer
   # Uncomment this block if you want to add custom indexing behavior:
   def generate_solr_document
     super.tap do |solr_doc|
-      solr_doc["creator_tesim"] = all_creators
+      solr_doc["creator_sim"] = solr_doc["creator_tesim"] = all_creators
       solr_doc["bulkrax_identifier_sim"] = object.bulkrax_identifier
       solr_doc["account_cname_tesim"] = Site.instance&.account&.cname
       solr_doc[CatalogController.title_field] = object.title.first


### PR DESCRIPTION
The facets still showed the URI but by setting `creator_sim` to the same value will fix this.

Ref:
  - https://github.com/scientist-softserv/utk-hyku/issues/592

