### PR TITLE
🐛 Fix undefined local variable `iiif_print`

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
   concern :oai_provider, BlacklightOaiProvider::Routes.new
 
   mount Hyrax::IiifAv::Engine, at: '/'
+  mount IiifPrint::Engine, at: '/'
   mount Riiif::Engine => 'images', as: :riiif if Hyrax.config.iiif_image_server?
 
   authenticate :user, lambda { |u| u.is_superadmin || u.is_admin } do


### PR DESCRIPTION
# Story

There was a change in this version of IIIF Print that needed an update to routes.rb.

Ref:
  - https://github.com/scientist-softserv/utk-hyku/issues/614
  - https://github.com/scientist-softserv/iiif_print/pull/302

# Expected Behavior Before Changes
Viewing the file set show page as an admin would result in a crash.

# Expected Behavior After Changes
Admins can view the file set show page without crashing.

# Screenshots / Video

![image](https://github.com/scientist-softserv/utk-hyku/assets/19597776/118da12d-1e46-4f26-9691-7ae295fffa65)
