### PR TITLE
🐛 Add parser mappings for bagit

### DIFF
--- a/config/initializers/bulkrax.rb
+++ b/config/initializers/bulkrax.rb
@@ -12,11 +12,13 @@ if ENV.fetch('HYKU_BULKRAX_ENABLED', 'true') == 'true'
     config.fill_in_blank_source_identifiers = ->(obj, index) { "#{Site.instance.account.name}-#{obj.importerexporter.id}-#{index}" }
 
     # Field mappings
-    config.field_mappings['Bulkrax::CsvParser'] = {
+    parser_mappings = {
       'bulkrax_identifier' => { from: ['source_identifier'], source_identifier: true, search_field: 'bulkrax_identifier_tesim' },
       'children' => { from: ['children'], split: /\s*[;|]\s*/, related_children_field_mapping: true },
       'parents' => { from: ['parents'], split: /\s*[;|]\s*/, related_parents_field_mapping: true }
     }
+    config.field_mappings['Bulkrax::CsvParser'] = parser_mappings
+    config.field_mappings['Bulkrax::BagitParser'] = parser_mappings
 
     # OVERRIDE Bulkrax v4.3.0: change the default "split" behavior
     config.default_field_mapping = lambda do |field|


### PR DESCRIPTION
# Story

Bagit exports were throwing errors because the parser_mappings were not set.  This commit adds the parser mappings for bagit.

Ref:
  - https://github.com/scientist-softserv/utk-hyku/issues/614
  - 
# Screenshots / Video

![image](https://github.com/scientist-softserv/utk-hyku/assets/19597776/9b7eefbe-b26f-402d-94ff-de99ec475df6)
