### PR TITLE
🐛 Change range limit javascript trigger

### DIFF
--- a/app/assets/javascripts/blacklight_range_limit/range_limit_distro_facets.js
+++ b/app/assets/javascripts/blacklight_range_limit/range_limit_distro_facets.js
@@ -4,7 +4,7 @@
    is (re-)drawn on screen possibly with a new size. target of event will be the DOM element
    containing the plot.  Used to resize slider to match. */
 
-   Blacklight.onLoad(function() {
+  $(document).on('turbolinks:load', function() {
     // ratio of width to height for desired display, multiply width by this ratio
     // to get height. hard-coded in for now.
     var display_ratio = 1/(1.618 * 2); // half a golden rectangle, why not

--- a/app/assets/javascripts/blacklight_range_limit/range_limit_slider.js
+++ b/app/assets/javascripts/blacklight_range_limit/range_limit_slider.js
@@ -1,6 +1,6 @@
 // for Blacklight.onLoad:
 
-Blacklight.onLoad(function() {
+$(document).on('turbolinks:load', function() {
 
   $(".range_limit .profile .range.slider_js").each(function() {
      var range_element = $(this);


### PR DESCRIPTION
Blacklight.onLoad was not working in production even though it works locally with assets debug true.  Changing it to
$(document).on('turbolinks:load'... instead.

Ref:
  - https://github.com/scientist-softserv/utk-hyku/issues/593

# Story

Refs #issuenumber

# Expected Behavior Before Changes

# Expected Behavior After Changes

# Screenshots / Video

<details>
<summary></summary>

</details>

# Notes