### PR TITLE
🎁 URIs to strings, now with resource type

### DIFF
--- a/app/indexers/allinson_flex/dynamic_indexer_behavior.rb
+++ b/app/indexers/allinson_flex/dynamic_indexer_behavior.rb
@@ -47,8 +47,8 @@ module AllinsonFlex
       end
 
       def local_authorities
-        # Hyku has these pluralized while m3 has these singularized
-        Qa::Authorities::Local.names.map(&:singularize)
+        # Hyku has these pluralized while m3 has these singularized, resource type is needed however
+        Qa::Authorities::Local.names.map(&:singularize) - ['resource_type']
       end
   end
 end

--- a/app/views/themes/dc_show/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/themes/dc_show/hyrax/base/_attribute_rows.html.erb
@@ -3,10 +3,15 @@
 <% presenter.dynamic_schema_service.view_properties.each_pair do | prop_key, prop_value | %>
   <%# @todo internationalisation %>
   <% next if prop_value[:admin_only] && !presenter.current_ability.current_user.admin? %>
-  <% value = presenter.attribute_to_html(prop_key, label: prop_value[:label], html_dl: true) %>
+  <%# Only rights_statement and license have special render_as options %>
+  <% value = if [:rights_statement, :license].include? prop_key %>
+    <% presenter.attribute_to_html(prop_key, render_as: prop_key, html_dl: true) %>
+  <% else %>
+    <% presenter.attribute_to_html(prop_key, label: prop_value[:label], html_dl: true) %>
+  <% end %>
   <% if value.present? && (prop_key != :abstract) %>
     <div class='metadata-group'>
       <%= value %>
     </div>
-  <% end %>  
+  <% end %>
 <% end %>


### PR DESCRIPTION
# Story
This commit will add a check for resource type as well as the external check.  Rights statement and license will now show as dereferenced links on the show page.

Ref:
  - https://github.com/scientist-softserv/utk-hyku/issues/592

# Expected Behavior Before Changes
URIs that are apart of resource type were not being dereferenced.

# Expected Behavior After Changes
URIs that are apart of resource type get dereferenced.  Rights statement and license also show up as strings but also links as well on the show page.

# Screenshots / Video
<img width="744" alt="image" src="https://github.com/scientist-softserv/utk-hyku/assets/19597776/6f58885c-7cfd-439f-a97e-38e84c94b7f1">

<img width="1001" alt="image" src="https://github.com/scientist-softserv/utk-hyku/assets/19597776/380f974e-380d-4dcf-b18c-4331dd3899a4">

