### PR TITLE
:gift: Adds collection sorting by publication and creation date

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -22,6 +22,14 @@ class CatalogController < ApplicationController
     'title_ssi'
   end
 
+  def self.published_field
+    'date_issued_d_ssi'
+  end
+
+  def self.created_field
+    'date_created_d_ssi'
+  end
+
   # CatalogController-scope behavior and configuration for BlacklightIiifSearch
   include BlacklightIiifSearch::Controller
 
@@ -396,6 +404,10 @@ class CatalogController < ApplicationController
     config.add_sort_field "#{uploaded_field} asc", label: "date uploaded \u25B2"
     config.add_sort_field "#{modified_field} desc", label: "date modified \u25BC"
     config.add_sort_field "#{modified_field} asc", label: "date modified \u25B2"
+    config.add_sort_field "#{published_field} desc", label: "date published \u25BC"
+    config.add_sort_field "#{published_field} asc", label: "date published \u25B2"
+    config.add_sort_field "#{created_field} desc", label: "date created \u25BC"
+    config.add_sort_field "#{created_field} asc", label: "date created \u25B2"
 
     # OAI Config fields
     config.oai = {

--- a/app/indexers/collection_indexer.rb
+++ b/app/indexers/collection_indexer.rb
@@ -13,6 +13,8 @@ class CollectionIndexer < Hyrax::CollectionIndexer
       solr_doc["bulkrax_identifier_sim"] = object.bulkrax_identifier
       solr_doc["account_cname_tesim"] = Site.instance&.account&.cname
       solr_doc[CatalogController.title_field] = object.title.first
+      solr_doc[CatalogController.published_field] = object.date_issued_d
+      solr_doc[CatalogController.created_field] = object.date_created_d
     end
   end
 


### PR DESCRIPTION
# Story

This commit adds collection search options for sorting by ascending and descending publication dates and ascending and descending creation dates to the dropdown menu.

Ref:
- https://github.com/scientist-softserv/utk-hyku/issues/650

# Expected Behavior Before Changes

There was no options to sort collections by publication date or creation date.

# Expected Behavior After Changes

The dropdown menu to filter searches now contains four new options: date created (asc), date created (desc), date published (asc), date published (desc). The new filter options work as expected to return search results that match the criteria as the top results.

# Screenshots / Video

### Drop Down Menu

<img width="1380" alt="Screenshot 2024-07-30 at 10 11 03 AM" src="https://github.com/user-attachments/assets/fedbad74-29fd-4014-8784-17d0f9d515b6">

### Functionality

https://github.com/user-attachments/assets/21b7d3d2-a11b-48b5-8601-fae96c84de19



