### PR TITLE
I655 browse collections updates

### DIFF
--- a/app/views/themes/dc_repository/hyrax/homepage/_browse_collections_grid_view.html.erb
+++ b/app/views/themes/dc_repository/hyrax/homepage/_browse_collections_grid_view.html.erb
@@ -1,9 +1,7 @@
-<div class='scroll'>
-  <div class='view-type-grid'>
-    <div class="row collections-row">
-      <% @collections_list.each do |collection| %>
-        <%= render 'browse_collections', collection: collection %>
-      <% end %>
-    </div>
+<div class='view-type-grid'>
+  <div class="row collections-row">
+    <% @collections_list.each do |collection| %>
+      <%= render 'browse_collections', collection: collection %>
+    <% end %>
   </div>
 </div>

--- a/app/views/themes/dc_repository/hyrax/homepage/_browse_collections_grid_view.html.erb
+++ b/app/views/themes/dc_repository/hyrax/homepage/_browse_collections_grid_view.html.erb
@@ -1,6 +1,6 @@
 <div class='view-type-grid'>
   <div class="row collections-row">
-    <% @collections_list.each do |collection| %>
+    <% collections_list.each do |collection| %>
       <%= render 'browse_collections', collection: collection %>
     <% end %>
   </div>

--- a/app/views/themes/dc_repository/hyrax/homepage/_browse_collections_list_view.html.erb
+++ b/app/views/themes/dc_repository/hyrax/homepage/_browse_collections_list_view.html.erb
@@ -1,9 +1,7 @@
-<div class='scroll'>
-  <div class='view-type-list'>
-    <div class="row collections-row">
-      <% @collections_list.each do |collection| %>
-        <%= render 'browse_collections', collection: collection %>
-      <% end %>
-    </div>
+<div class='view-type-list'>
+  <div class="row collections-row">
+    <% @collections_list.each do |collection| %>
+      <%= render 'browse_collections', collection: collection %>
+    <% end %>
   </div>
 </div>

--- a/app/views/themes/dc_repository/hyrax/homepage/_browse_collections_list_view.html.erb
+++ b/app/views/themes/dc_repository/hyrax/homepage/_browse_collections_list_view.html.erb
@@ -1,6 +1,6 @@
 <div class='view-type-list'>
   <div class="row collections-row">
-    <% @collections_list.each do |collection| %>
+    <% collections_list.each do |collection| %>
       <%= render 'browse_collections', collection: collection %>
     <% end %>
   </div>

--- a/app/views/themes/dc_repository/hyrax/homepage/_browse_collections_section.html.erb
+++ b/app/views/themes/dc_repository/hyrax/homepage/_browse_collections_section.html.erb
@@ -35,11 +35,12 @@
       </header>
       <!-- Tab panes -->
       <div class="tab-content">
+        <% collections_list = @collections_list.shuffle %>
         <div role="tabpanel" class="tab-pane active" id="view-type-grid">
-          <%= render "browse_collections_grid_view" %>
+          <%= render "browse_collections_grid_view", collections_list: collections_list %>
         </div>
         <div role="tabpanel" class="tab-pane" id="view-type-list">
-          <%= render "browse_collections_list_view" %>
+          <%= render "browse_collections_list_view", collections_list: collections_list %>
         </div>
       </div>
     </div>

--- a/app/views/themes/dc_repository/hyrax/homepage/_browse_collections_section.html.erb
+++ b/app/views/themes/dc_repository/hyrax/homepage/_browse_collections_section.html.erb
@@ -11,13 +11,13 @@
         <div class="browse-collections--view d-flex">
           <ul class="nav nav-tabs" role="tablist">
             <li role="presentation" class="active">
-              <a href="#view-type-list" aria-controls="view-type-list" role="tab" data-toggle="tab">
-                <button class="button-toggle d-flex"><i class="fa fa-list" aria-hidden="true"></i><span>List</span></button>
+              <a href="#view-type-grid" aria-controls="view-type-grid" role="tab" data-toggle="tab">
+                <button class="button-toggle d-flex"><i class="fa fa-th" aria-hidden="true"></i><span>Grid</span></button>
               </a>
             </li>
             <li role="presentation">
-              <a href="#view-type-grid" aria-controls="view-type-grid" role="tab" data-toggle="tab">
-                <button class="button-toggle d-flex"><i class="fa fa-th" aria-hidden="true"></i><span>Grid</span></button>
+              <a href="#view-type-list" aria-controls="view-type-list" role="tab" data-toggle="tab">
+                <button class="button-toggle d-flex"><i class="fa fa-list" aria-hidden="true"></i><span>List</span></button>
               </a>
             </li>
           </div>
@@ -35,11 +35,11 @@
       </header>
       <!-- Tab panes -->
       <div class="tab-content">
-        <div role="tabpanel" class="tab-pane active" id="view-type-list">
-          <%= render "browse_collections_list_view" %>
-        </div>
-        <div role="tabpanel" class="tab-pane" id="view-type-grid">
+        <div role="tabpanel" class="tab-pane active" id="view-type-grid">
           <%= render "browse_collections_grid_view" %>
+        </div>
+        <div role="tabpanel" class="tab-pane" id="view-type-list">
+          <%= render "browse_collections_list_view" %>
         </div>
       </div>
     </div>


### PR DESCRIPTION
# Story

Epic: Make Browse Collections grid default view and set sort to random, and remove scroll for collection section. 

Refs
- [x] https://github.com/scientist-softserv/utk-hyku/issues/667
- [x] https://github.com/scientist-softserv/utk-hyku/issues/668
- [x] https://github.com/scientist-softserv/utk-hyku/issues/669

# Expected Behavior Before Changes

1. Collections section had list view as the default
2. Collections were displayed in the default order from the database
3. Collections section had its own scroll as well as the page scroll  

# Expected Behavior After Changes

1. Collections section has a default grid view
2. Collections are now randomized on each page load, toggling between list and grid view will show the same randomized order
3. Collections section no longer has its own scroll, the only scroll is on the full page

# Screenshots / Video

https://github.com/user-attachments/assets/10e5fd6d-25bf-406d-a8f0-0e96e20e9f40

# Notes

The epic was broken into three tickets. Each commit on this PR represents one story. The changes were smaller than originally expected. 