### PR TITLE
🎁 change clover iiif about > homepage label

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -61,3 +61,4 @@
 //= require flot/jquery.flot.selection.js
 //= require bootstrap-slider
 //= require_tree ./blacklight_range_limit
+//= require clover_iiif_custom

--- a/app/assets/javascripts/clover_iiif_custom.js
+++ b/app/assets/javascripts/clover_iiif_custom.js
@@ -1,0 +1,21 @@
+$(function() {
+  function updateIframeContent() {
+    var iframeContent = $('#clover-iiif-iframe').contents();
+    iframeContent.find(".manifest-property-title:contains('Homepage')").text('List of items');
+    iframeContent.find("a:not([target])").attr('target', '_parent');
+  }
+
+  function observeIframe() {
+    var iframe = $('#clover-iiif-iframe')[0];
+    var iframeDocument = iframe.contentDocument || iframe.contentWindow.document;
+    var observer = new MutationObserver(function(mutations) {
+      updateIframeContent();
+    });
+    observer.observe(iframeDocument, { childList: true, subtree: true });
+    updateIframeContent();
+  }
+
+  $('#clover-iiif-iframe').on('load', function() {
+    observeIframe();
+  });
+});


### PR DESCRIPTION
# Story

Video "About" section contains "homepage" – link to self

This commit updates the About section text label from `"Homepage"` to
`"Link to item"`. Since this label comes from the clover iiif
JavaScript, it was necessary to create a custom function that finds the
label and overrides it.

There was also a bug that opened the entire page inside the iframe
window. The custom iiif clover override function also added a target
parent to the link to prevent this issue.

Ref:
- [x] https://github.com/scientist-softserv/utk-hyku/issues/659

# Expected Behavior Before Changes

- Clover iiif player labeled as "Homepage" 
- When link was clicked, the entire browser window opened inside the player

# Expected Behavior After Changes

- Clover iiif player labeled as "Link to item" 
- When link was clicked, the entire browser window opened inside the player

# Screenshots / Video

- Link update
![image](https://github.com/user-attachments/assets/125f1e21-92fe-4acf-b218-a6601daa6264)

- Nested webpage bug fix

https://github.com/user-attachments/assets/19f1c698-5762-49f5-aea2-17f9b7b9ccf9