### PR TITLE
I646 search dropdown

### DIFF
--- a/app/assets/javascripts/hyrax/search.js
+++ b/app/assets/javascripts/hyrax/search.js
@@ -1,4 +1,4 @@
-// Override Hyrax v3.6.0 to fix the set label
+// Override Hyrax v3.6.0 to fix the set label and modify set form action to support searching with resource types
 
 (function($){
   Hyrax.Search = function (element) {
@@ -33,6 +33,11 @@
 
     setFormAction: function(path) {
       this.$element.attr('action', path);
+      this.$element.find('input[type="hidden"]').remove();
+      var params = new URLSearchParams(path.split('?')[1]);
+      for (const [key, value] of params) {
+        this.$element.append('<input type="hidden" name="' + key + '" value="' + value + '">');
+      }
     },
 
     getLabelForValue: function(value) {

--- a/app/assets/javascripts/hyrax/search.js
+++ b/app/assets/javascripts/hyrax/search.js
@@ -1,9 +1,12 @@
+// Override Hyrax v3.6.0 to fix the set label
+
 (function($){
   Hyrax.Search = function (element) {
     this.$element = $(element);
 
     this.init = function() {
       this.$label = this.$element.find('[data-search-element="label"]');
+      this.$visibleLabel = this.$element.find('.dropdown-toggle').find('span[aria-hidden="true"]');
       this.$items = this.$element.find('[data-search-option]');
       this.setDefault();
     }
@@ -43,6 +46,7 @@
 
     setLabel: function(label) {
       this.$label.html(label);
+      this.$visibleLabel.html(label);
     }
 
   }

--- a/app/assets/javascripts/hyrax/search.js
+++ b/app/assets/javascripts/hyrax/search.js
@@ -1,0 +1,64 @@
+(function($){
+  Hyrax.Search = function (element) {
+    this.$element = $(element);
+
+    this.init = function() {
+      this.$label = this.$element.find('[data-search-element="label"]');
+      this.$items = this.$element.find('[data-search-option]');
+      this.setDefault();
+    }
+
+    this.init();
+    this.attachEvents();
+  }
+
+
+  Hyrax.Search.prototype = {
+    attachEvents: function() {
+
+      _this = this;
+      this.$items.on('click', function(event) {
+        event.preventDefault();
+        _this.clicked($(this))
+      });
+    },
+
+    clicked: function($anchor) {
+      this.setLabel($anchor.data('search-label'));
+      this.setFormAction($anchor.data('search-option'));
+    },
+
+    setFormAction: function(path) {
+      this.$element.attr('action', path);
+    },
+
+    getLabelForValue: function(value) {
+      selected = this.$element.find('[data-search-option="'+ value +'"]');
+      return selected.data('search-label');
+    },
+
+    setDefault: function() {
+      this.setLabel(this.getLabelForValue(this.$element.attr('action')));
+    },
+
+    setLabel: function(label) {
+      this.$label.html(label);
+    }
+
+  }
+
+  $.fn.search = function(option) {
+    return this.each(function() {
+      var $this = $(this);
+      var data  = $this.data('search');
+
+      if (!data) $this.data('search', (data = new Hyrax.Search(this)));
+    })
+  }
+
+})(jQuery);
+
+
+Blacklight.onLoad(function() {
+  $('#search-form-header').search();
+});

--- a/app/assets/stylesheets/themes/dc_repository.scss
+++ b/app/assets/stylesheets/themes/dc_repository.scss
@@ -361,7 +361,7 @@ body.dc_repository {
         border-radius: 0 !important;
         position: relative;
         z-index: 3;
-        padding: 0 !important;
+        padding: 0 1em !important;
         min-height: auto;
         border: none;
         border-left: 2px solid $gray-0;

--- a/app/views/themes/dc_repository/catalog/_search_form.html.erb
+++ b/app/views/themes/dc_repository/catalog/_search_form.html.erb
@@ -24,14 +24,13 @@
               <%= link_to t("hyrax.search.form.option.all.label_long", application_name: application_name), "#",
                   data: { "search-option" => main_app.search_catalog_path, "search-label" => t("hyrax.search.form.option.all.label_short") } %>
             </li>
-            <li>
-              <%= link_to t("hyrax.search.form.option.my_works.label_long"), "#",
-                  data: { "search-option" => hyrax.my_works_path, "search-label" => t("hyrax.search.form.option.my_works.label_short") } %>
-            </li>
-            <li>
-              <%= link_to t("hyrax.search.form.option.my_collections.label_long"), "#",
-                  data: { "search-option" => hyrax.my_collections_path, "search-label" => t("hyrax.search.form.option.my_collections.label_short") } %>
-            </li>
+            <% Hyrax.config.registered_curation_concern_types.map(&:titleize).each do |concern| %>
+              <% next if concern == 'Attachment' %>
+              <li>
+                <%= link_to concern, "#",
+                    data: { "search-option" => main_app.search_catalog_path(f: { human_readable_type_sim: [concern] }), "search-label" => concern } %>
+              </li>
+            <% end %>
           <% end %>
 
         </ul>

--- a/app/views/themes/dc_repository/catalog/_search_form.html.erb
+++ b/app/views/themes/dc_repository/catalog/_search_form.html.erb
@@ -5,34 +5,28 @@
   <%= hidden_field_tag :search_field, 'all_fields' %>
   <div class="form-group">
     <%# OVERRIDE: Hyrax v3.4.1 Remove label from form-group %>
-
     <div class="input-group">
       <%= text_field_tag :q, current_search_parameters , class: "q form-control", id: "search-field-header", placeholder: t("hyrax.search.form.q.placeholder") %>
       <%# OVERRIDE: Hyrax v3.4.1 switch button order %>
       <div class="input-group-btn">
-        <% if current_user %>
-          <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown" aria-expanded="false">
-
-            <span class="sr-only" data-search-element="label"><%= t("hyrax.search.form.option.all.label_long", application_name: application_name) %></span>
-            <span aria-hidden="true"><%= t("hyrax.search.form.option.all.label_short") %></span>
-            <%# OVERRIDE: Hyrax v3.4.1 change dropdown icon %>
-            <span class="fa fa-thin fa-chevron-down"></span>
-          </button>
-
-          <ul class="dropdown-menu pull-right">
+        <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown" aria-expanded="false">
+          <span class="sr-only" data-search-element="label"><%= t("hyrax.search.form.option.all.label_long", application_name: application_name) %></span>
+          <span aria-hidden="true"><%= t("hyrax.search.form.option.all.label_short") %></span>
+          <%# OVERRIDE: Hyrax v3.4.1 change dropdown icon %>
+          <span class="fa fa-thin fa-chevron-down"></span>
+        </button>
+        <ul class="dropdown-menu pull-right">
+          <li>
+            <%= link_to t("hyrax.search.form.option.all.label_long", application_name: application_name), "#",
+                data: { "search-option" => main_app.search_catalog_path, "search-label" => t("hyrax.search.form.option.all.label_short") } %>
+          </li>
+          <% Hyrax.config.registered_curation_concern_types.map(&:titleize).each do |concern| %>
+            <% next if concern == 'Attachment' %>
             <li>
-              <%= link_to t("hyrax.search.form.option.all.label_long", application_name: application_name), "#",
-                  data: { "search-option" => main_app.search_catalog_path, "search-label" => t("hyrax.search.form.option.all.label_short") } %>
+              <%= link_to concern, "#",
+                  data: { "search-option" => main_app.search_catalog_path(f: { human_readable_type_sim: [concern] }), "search-label" => concern } %>
             </li>
-            <% Hyrax.config.registered_curation_concern_types.map(&:titleize).each do |concern| %>
-              <% next if concern == 'Attachment' %>
-              <li>
-                <%= link_to concern, "#",
-                    data: { "search-option" => main_app.search_catalog_path(f: { human_readable_type_sim: [concern] }), "search-label" => concern } %>
-              </li>
-            <% end %>
           <% end %>
-
         </ul>
         <button type="submit" class="btn" id="search-submit-header">
           <span class="glyphicon glyphicon-search"></span>
@@ -40,6 +34,5 @@
         </button>
       </div><!-- /.input-group-btn -->
     </div><!-- /.input-group -->
-
   </div><!-- /.form-group -->
 <% end %>


### PR DESCRIPTION
# Story

Remove "My Works" and "My Collections" from search drop down and adds all type facets

Refs
- [x] https://github.com/scientist-softserv/utk-hyku/issues/646

# Expected Behavior Before Changes

Only logged in users can see search options that included `"All of Hyku"`, `"My Collections"`, and `"My Works"` in the dropdown menu

# Expected Behavior After Changes

All users can see the search options for `"All of Hyku"`, `"Generic Work"`, `"Image"`, `"Audio"`, `"Book"`, `"Compound Object"`, `"Newspaper"`, `"Pdf"`, and `"Video"`.

# Screenshots / Video

https://github.com/user-attachments/assets/44cf0157-cc0e-4ea1-9e59-2cc5f9b6f45b