### PR TITLE
🎁 Configure OAI-PMH sets around collections

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -421,7 +421,8 @@ class CatalogController < ApplicationController
       document: {
         limit: 100, # number of records returned with each request, default: 15
         set_fields: [ # ability to define ListSets, optional, default: nil
-          { label: 'collection', solr_field: 'isPartOf_ssim' }
+          { label: 'admin_set', solr_field: 'isPartOf_ssim' },
+          { label: 'collection', solr_field: 'member_of_collections_ssim' }
         ]
       }
     }


### PR DESCRIPTION
# Story

This commit will add collections as sets to the OAI-PMH feed.

Ref:
- https://github.com/scientist-softserv/utk-hyku/issues/666

# Expected Behavior Before Changes
Users were not able to see collections as sets in the OAI feed.

# Expected Behavior After Changes
Users now can see collections as sets in the OAI feed.

# Screenshots / Video
<img width="532" alt="image" src="https://github.com/user-attachments/assets/3c2b1969-d069-40d7-bae1-9dde0be448e2">

# Notes
We're going to have to test this with Meredith because I'm not super familiar with OAI.