### PR TITLE
🐛 Dropdown options for created and published

### DIFF
--- a/app/indexers/app_indexer.rb
+++ b/app/indexers/app_indexer.rb
@@ -22,8 +22,12 @@ class AppIndexer < Hyrax::WorkIndexer
       # using Array() vs Array.wrap() since the objects are ActiveTriples::Relation
       # Array.wrap() will create nested arrays
       solr_doc[CatalogController.title_field] = Array(object.title).first
-      solr_doc[CatalogController.published_field] = Array(object.date_issued_d).first
-      solr_doc[CatalogController.created_field] = Array(object.date_created_d).first
+      solr_doc[CatalogController.published_field] = (
+        Array(object.date_issued_d).first if object.respond_to?(:date_issued_d)
+      )
+      solr_doc[CatalogController.created_field] = (
+        Array(object.date_created_d).first if object.respond_to?(:date_created_d)
+      )
     end
   end
 

--- a/app/indexers/app_indexer.rb
+++ b/app/indexers/app_indexer.rb
@@ -19,7 +19,11 @@ class AppIndexer < Hyrax::WorkIndexer
       solr_doc["bulkrax_identifier_ssim"] = object.bulkrax_identifier
       # tesim is the wrong field for this, but until we reindex everything we need to keep it
       solr_doc["bulkrax_identifier_tesim"] = object.bulkrax_identifier
-      solr_doc[CatalogController.title_field] = object.title.first
+      # using Array() vs Array.wrap() since the objects are ActiveTriples::Relation
+      # Array.wrap() will create nested arrays
+      solr_doc[CatalogController.title_field] = Array(object.title).first
+      solr_doc[CatalogController.published_field] = Array(object.date_issued_d).first
+      solr_doc[CatalogController.created_field] = Array(object.date_created_d).first
     end
   end
 

--- a/app/indexers/collection_indexer.rb
+++ b/app/indexers/collection_indexer.rb
@@ -12,9 +12,9 @@ class CollectionIndexer < Hyrax::CollectionIndexer
       solr_doc["creator_sim"] = solr_doc["creator_tesim"] = all_creators
       solr_doc["bulkrax_identifier_sim"] = object.bulkrax_identifier
       solr_doc["account_cname_tesim"] = Site.instance&.account&.cname
-      solr_doc[CatalogController.title_field] = object.title.first
-      solr_doc[CatalogController.published_field] = object.date_issued_d
-      solr_doc[CatalogController.created_field] = object.date_created_d
+      solr_doc[CatalogController.title_field] = Array(object.title).first
+      solr_doc[CatalogController.published_field] = Array(object.date_issued_d).first
+      solr_doc[CatalogController.created_field] = Array(object.date_created_d).first
     end
   end
 


### PR DESCRIPTION
# Story

This commit addresses a bug in the dropdown menu search options for created and published. The options were not behaving as expected due to the date being a ActiveTriples::Relation rather than a string. The changes ensure all dates are converted into an array then the first date is extracted.

Ref:
- https://github.com/scientist-softserv/utk-hyku/issues/650

# Expected Behavior Before Changes

Filtering by created (asc and desc) and published (asc and desc) did not produce any result in staging.

# Expected Behavior After Changes

User should be able to filter by created (asc and desc) and published (asc and desc).

# Screenshots / Video

# Notes

This is a bug in staging.
Reindexing is required.