### PR TITLE
Remove opacity from background container so images will display

### DIFF
--- a/app/assets/stylesheets/themes/dc_repository.scss
+++ b/app/assets/stylesheets/themes/dc_repository.scss
@@ -239,7 +239,6 @@ body.dc_repository {
       align-self: flex-end;
       background-size: cover;
       background-position: center;
-      opacity: 0;
       transition: opacity 2s ease-in-out;
     }
 


### PR DESCRIPTION
# Story

Refs #686 

# Expected Behavior Before Changes
- Opacity appears to be hiding the image
# Expected Behavior After Changes
- Image displays as expected
# Screenshots / Video
Before:
![image](https://github.com/user-attachments/assets/90efbd96-3fa2-445d-a513-38a3d9817c23)

After:
![image](https://github.com/user-attachments/assets/ef897bf6-b278-4031-b1c1-782a8faab1df)

<details>
<summary></summary>

</details>

# Notes
The original issue might be that the .active class is not triggering as expected to get the transition to bring the image in but I don't have a great way to test this out here.