### PR TITLE
🐛 Remove i18n from oai repository url

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -413,7 +413,7 @@ class CatalogController < ApplicationController
     config.oai = {
       provider: {
         repository_name: ->(controller) { controller.send(:current_account)&.name.presence },
-        # repository_url:  ->(controller) { controller.oai_catalog_url },
+        repository_url:  ->(controller) { controller.oai_catalog_url.split('?locale').first }, # remove i18n for oai URL
         record_prefix: ->(controller) { controller.send(:current_account).oai_prefix },
         admin_email:   ->(controller) { controller.send(:current_account).oai_admin_email },
         sample_id:     ->(controller) { controller.send(:current_account).oai_sample_identifier }


### PR DESCRIPTION
This commit will address the following failure from repox OAI-PMH Data Provider Validator:

FAIL baseURL supplied
'https://digitalcollections.lib.utk.edu/catalog/oai' does not match the baseURL in the Identify response
'https://digitalcollections.lib.utk.edu/catalog/oai?locale=en'. The baseURL you enter must EXACTLY match the baseURL returned in the Identify response. It must match in case (http://Wibble.org/ does not match http://wibble.org/) and include any trailing slashes etc.

The problem was that the locale was being added, so this commit will remove that.

Ref:
- https://github.com/notch8/utk-hyku/issues/691

## Before
```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-stylesheet type="text/xsl" href="/assets/blacklight_oai_provider/oai2-215c34219a0c518cf7dde42605d91175cbfd22c3f0ce528f795eae128dd1d872.xsl"?>
<OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
  <responseDate>2025-02-14T23:43:58Z</responseDate>
  <request verb="Identify">https://dev.utk-hyku.test/catalog/oai?locale=en</request><!-- ##### has locale -->
  <Identify>
    <repositoryName>dev</repositoryName>
    <baseURL>https://dev.utk-hyku.test/catalog/oai?locale=en</baseURL>
    <protocolVersion>2.0</protocolVersion>
    <adminEmail>changeme@example.com</adminEmail>
    <earliestDatestamp>2025-02-14T17:49:08Z</earliestDatestamp>
    <deletedRecord>transient</deletedRecord>
    <granularity>YYYY-MM-DDThh:mm:ssZ</granularity>
    <description>
      <oai-identifier xmlns="http://www.openarchives.org/OAI/2.0/oai-identifier" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai-identifier http://www.openarchives.org/OAI/2.0/oai-identifier.xsd">
        <scheme>oai</scheme>
        <repositoryIdentifier>hyku</repositoryIdentifier>
        <delimiter>:</delimiter>
        <sampleIdentifier>oai:hyku:806bbc5e-8ebe-468c-a188-b7c14fbe34df</sampleIdentifier>
      </oai-identifier>
    </description>
  </Identify>
</OAI-PMH>
```

##
After
```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-stylesheet type="text/xsl" href="/assets/blacklight_oai_provider/oai2-215c34219a0c518cf7dde42605d91175cbfd22c3f0ce528f795eae128dd1d872.xsl"?>
<OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
  <responseDate>2025-02-14T23:41:03Z</responseDate>
  <request verb="Identify">https://dev.utk-hyku.test/catalog/oai</request>
  <Identify>
    <repositoryName>dev</repositoryName>
    <baseURL>https://dev.utk-hyku.test/catalog/oai</baseURL><!-- ##### no locale -->
    <protocolVersion>2.0</protocolVersion>
    <adminEmail>changeme@example.com</adminEmail>
    <earliestDatestamp>2025-02-14T17:49:08Z</earliestDatestamp>
    <deletedRecord>transient</deletedRecord>
    <granularity>YYYY-MM-DDThh:mm:ssZ</granularity>
    <description>
      <oai-identifier xmlns="http://www.openarchives.org/OAI/2.0/oai-identifier" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai-identifier http://www.openarchives.org/OAI/2.0/oai-identifier.xsd">
        <scheme>oai</scheme>
        <repositoryIdentifier>hyku</repositoryIdentifier>
        <delimiter>:</delimiter>
        <sampleIdentifier>oai:hyku:806bbc5e-8ebe-468c-a188-b7c14fbe34df</sampleIdentifier>
      </oai-identifier>
    </description>
  </Identify>
</OAI-PMH>
```