### PR TITLE
🎁 Convert subject URIs to string values

### DIFF
--- a/app/indexers/app_indexer.rb
+++ b/app/indexers/app_indexer.rb
@@ -14,7 +14,9 @@ class AppIndexer < Hyrax::WorkIndexer
   # Uncomment this block if you want to add custom indexing behavior:
   def generate_solr_document
     super.tap do |solr_doc|
-      solr_doc["creator_sim"] = all_creators
+      solr_doc["creator_sim"] = convert_uri_to_value(SolrDocument.creator_fields)
+      solr_doc["language_sim"] = solr_doc["language_tesim"] = convert_uri_to_value(["language"])
+      solr_doc["language_local_sim"] = solr_doc["language_local_tesim"] = convert_uri_to_value(["language"])
       solr_doc["account_cname_tesim"] = Site.instance&.account&.cname
       solr_doc["bulkrax_identifier_ssim"] = object.bulkrax_identifier
       # tesim is the wrong field for this, but until we reindex everything we need to keep it
@@ -30,10 +32,4 @@ class AppIndexer < Hyrax::WorkIndexer
       )
     end
   end
-
-  private
-
-    def all_creators
-      SolrDocument.creator_fields.map { |prop| uri_to_value_for(object.try(prop)) }.flatten.compact
-    end
 end

--- a/app/indexers/collection_indexer.rb
+++ b/app/indexers/collection_indexer.rb
@@ -9,7 +9,10 @@ class CollectionIndexer < Hyrax::CollectionIndexer
   # Uncomment this block if you want to add custom indexing behavior:
   def generate_solr_document
     super.tap do |solr_doc|
-      solr_doc["creator_sim"] = solr_doc["creator_tesim"] = all_creators
+      solr_doc["creator_sim"] = solr_doc["creator_tesim"] = convert_uri_to_value(SolrDocument.creator_fields)
+      solr_doc["subject_sim"] = solr_doc["subject_tesim"] = convert_uri_to_value(['subject'])
+      solr_doc["contributor_sim"] = solr_doc["contributor_tesim"] = convert_uri_to_value(['contributor'])
+      solr_doc["language_sim"] = solr_doc["language_tesim"] = convert_uri_to_value(['language'])
       solr_doc["bulkrax_identifier_sim"] = object.bulkrax_identifier
       solr_doc["account_cname_tesim"] = Site.instance&.account&.cname
       solr_doc[CatalogController.title_field] = Array(object.title).first
@@ -17,10 +20,4 @@ class CollectionIndexer < Hyrax::CollectionIndexer
       solr_doc[CatalogController.created_field] = Array(object.date_created_d).first
     end
   end
-
-  private
-
-    def all_creators
-      SolrDocument.creator_fields.map { |prop| uri_to_value_for(object.try(prop)) }.flatten.compact
-    end
 end

--- a/app/indexers/uri_to_string_behavior.rb
+++ b/app/indexers/uri_to_string_behavior.rb
@@ -6,6 +6,18 @@ module UriToStringBehavior
   # UTK uses this label to house the value that needs to be rendered
   LABEL = "http://www.w3.org/2004/02/skos/core#prefLabel"
 
+  # Converts URIs to their corresponding values for a list of fields.
+  #
+  # @param fields [Array<Symbol>] list of property names to process
+  # @return [Array<String>] flattened array of resolved values with blanks removed
+  #
+  # @example
+  #   convert_uri_to_value(['creator', 'contributor'])
+  #   #=> ["University of Tennessee", "John Die"]
+  def convert_uri_to_value(fields)
+    fields.map { |prop| uri_to_value_for(object.try(prop)) }.flatten.compact
+  end
+
   # Retrieves a value for a given URI.
   #
   # @param value [String] the value to retrieve. If this value starts with 'http', it is treated as a URI.


### PR DESCRIPTION
This commit will make it so the subject URIs on collections are converted to string values.

Ref:
- https://github.com/notch8/utk-hyku/issues/592

## Before
<img width="1289" alt="image" src="https://github.com/user-attachments/assets/2c943d95-3b5c-4857-a006-be9cb933f17a" />

## After
<img width="1275" alt="image" src="https://github.com/user-attachments/assets/20783e9e-cb40-4416-a40e-cb8ff5c9b735" />
