### PR TITLE
🎁 Show thumbnail if attachments are institution

### DIFF
--- a/app/assets/stylesheets/themes/dc_show.scss
+++ b/app/assets/stylesheets/themes/dc_show.scss
@@ -166,6 +166,17 @@ body.dc_show {
 
   .uv-panel {
     padding: 0;
+
+    .thumbnail-container {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      text-align: center;
+
+      .representative-media {
+        width: auto;
+      }
+    }
   }
 
   .items-panel {

--- a/app/helpers/hyrax/iiif_helper.rb
+++ b/app/helpers/hyrax/iiif_helper.rb
@@ -36,5 +36,10 @@ module Hyrax
 
       "&q=#{url_encode(q)}" if q.present?
     end
+
+    # Checks if work has attachments with visibility of "Institution" ("authenticated")
+    def attachments_with_institution_visibility?(presenter)
+      presenter.solr_document.ordered_member_ids.all? { |id| ::SolrDocument.find(id).visibility == 'authenticated' }
+    end
   end
 end

--- a/app/views/themes/dc_show/hyrax/base/_representative_media.html.erb
+++ b/app/views/themes/dc_show/hyrax/base/_representative_media.html.erb
@@ -1,0 +1,14 @@
+<%#
+  OVERRIDE Hyrax v3.6.0 to check if the work has all attachments that are set to institution.
+  If so then the UV should not show and instead display the thumbnail.
+%>
+
+<% if presenter.representative_id.present? && presenter.representative_presenter.present? %>
+  <% if defined?(viewer) && viewer && (!attachments_with_institution_visibility?(presenter) || current_user) %>
+    <%= iiif_viewer_display presenter %>
+  <% else %>
+    <%= render media_display_partial(presenter.representative_presenter), file_set: presenter.representative_presenter  %>
+  <% end %>
+<% else %>
+  <%= image_tag 'default.png', class: "canonical-image", alt: 'default representative image' %>
+<% end %>

--- a/app/views/themes/dc_show/hyrax/file_sets/media_display/_image.html.erb
+++ b/app/views/themes/dc_show/hyrax/file_sets/media_display/_image.html.erb
@@ -1,0 +1,10 @@
+<%#
+  OVERRIDE Hyrax v3.6.0 to remove the download link so it doesn't show on the show page
+%>
+
+<div class="thumbnail-container">
+  <%= image_tag thumbnail_url(file_set),
+                class: "representative-media",
+                alt: "",
+                role: "presentation" %>
+</div>


### PR DESCRIPTION
This commit will add logic to only show the thumbnail and not the UV when the work has attachments that are set to institution visibility. Also added minor styling so the thumbnail is centered on the show page and not aligned to the left.  This allows for the thumbnail and metadata for the works in the Archivision to be publicly visibile.  The attachments and file sets would need to be set to "Institution" (authenticated).

Ref:
- https://github.com/notch8/utk-hyku/issues/647

![image](https://github.com/user-attachments/assets/b02b5e88-62cf-4b6e-86c0-1c8dd9747814)
