### PR TITLE
🐛 Adds "more" option to facets with 5+ items

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -99,7 +99,13 @@ class CatalogController < ApplicationController
     config.add_facet_field 'based_near_label_sim', limit: 5
     config.add_facet_field 'publisher_sim', limit: 5
     config.add_facet_field 'file_format_sim', limit: 5
-    config.add_facet_field 'member_of_collections_ssim', limit: 5, label: 'Collections'
+    config.add_facet_field 'form_local_sim', label: "Form", limit: 5
+    config.add_facet_field 'intermediate_provider_sim', label: "Intermediate Provider", limit: 5
+    config.add_facet_field 'license_sim', label: "License", limit: 5
+    config.add_facet_field 'resource_type_sim', label: "Resource Type", limit: 5
+    config.add_facet_field 'rights_statement_sim', label: "Rights Statement", limit: 5
+    config.add_facet_field 'member_of_collections_sim', label: "Collections", limit: 5
+    config.add_facet_field 'spatial_sim', label: "Location", limit: 5
 
     # Have BL send all facet field names to Solr, which has been the default
     # previously. Simply remove these lines if you'd rather use Solr request

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
-RSpec.describe CatalogController do
+require 'rails_helper'
+
+RSpec.describe CatalogController, type: :controller do
   describe "GET /show" do
     let(:file_set) { create(:file_set) }
 
@@ -21,6 +23,69 @@ RSpec.describe CatalogController do
       it "is redirects to sign in" do
         get :show, params: { id: file_set }
         expect(response).to redirect_to new_user_session_path
+      end
+    end
+  end
+
+  describe "facet configuration" do
+    let(:config) { described_class.blacklight_config }
+    let(:facet_fields) { config.facet_fields }
+
+    it "configures facet fields with correct limits" do
+      expect(facet_fields['human_readable_type_sim'].limit).to eq 5
+      expect(facet_fields['creator_sim'].limit).to eq 5
+      expect(facet_fields['contributor_sim'].limit).to eq 5
+      expect(facet_fields['keyword_sim'].limit).to eq 5
+      expect(facet_fields['subject_sim'].limit).to eq 5
+      expect(facet_fields['language_sim'].limit).to eq 5
+      expect(facet_fields['based_near_label_sim'].limit).to eq 5
+      expect(facet_fields['publisher_sim'].limit).to eq 5
+      expect(facet_fields['file_format_sim'].limit).to eq 5
+      expect(facet_fields['form_local_sim'].limit).to eq 5
+      expect(facet_fields['intermediate_provider_sim'].limit).to eq 5
+      expect(facet_fields['license_sim'].limit).to eq 5
+      expect(facet_fields['resource_type_sim'].limit).to eq 5
+      expect(facet_fields['rights_statement_sim'].limit).to eq 5
+      expect(facet_fields['member_of_collections_sim'].limit).to eq 5
+      expect(facet_fields['spatial_sim'].limit).to eq 5
+    end
+
+    it "configures facet fields with correct labels" do
+      expect(facet_fields['date_created_d_sim'].label).to eq 'Date Created'
+      expect(facet_fields['contributor_sim'].label).to eq 'Contributor'
+      expect(facet_fields['form_local_sim'].label).to eq 'Form'
+      expect(facet_fields['intermediate_provider_sim'].label).to eq 'Intermediate Provider'
+      expect(facet_fields['license_sim'].label).to eq 'License'
+      expect(facet_fields['resource_type_sim'].label).to eq 'Resource Type'
+      expect(facet_fields['rights_statement_sim'].label).to eq 'Rights Statement'
+      expect(facet_fields['member_of_collections_sim'].label).to eq 'Collections'
+      expect(facet_fields['spatial_sim'].label).to eq 'Location'
+    end
+
+    describe "facet more options" do
+      before do
+        # Clean the database before running this test
+        GenericWork.destroy_all
+
+        # Create 7 works with different form values
+        7.times do |i|
+          create(:generic_work, form_local: ["Form #{i}"])
+        end
+      end
+
+      it "shows more button when there are more items than the display limit" do
+        get :index
+        expect(response).to be_successful
+
+        facet_response = assigns(:response)
+        form_facet = facet_response.aggregations['form_local_sim']
+
+        # Blacklight looks for limit + 1 items (5 + 1 = 6) to determine whether to show the more button
+        expect(form_facet.items.length).to eq 6
+        # Verify the configured limit is 5
+        expect(facet_fields['form_local_sim'].limit).to eq 5
+        # Verify there are more items than shown
+        expect(form_facet.items.length).to eq(facet_fields['form_local_sim'].limit + 1)
       end
     end
   end


### PR DESCRIPTION
# Story: [i656] Some facets don't have a "More" option

Ref:
- https://github.com/notch8/utk-hyku/issues/656

## Expected Behavior Before Changes

The form facet as well as other fields did not have a "more" option for 5+ items

## Expected Behavior After Changes

This commit ensures all facet options have a "more" option when there are over five items in the facet. This is to prevent the facet list from becoming too long.

## Screenshots / Video

<details>
<summary>Video: Before changes</summary>

https://github.com/user-attachments/assets/467f18b0-5d48-4c45-853c-e4c561d78a9e

</details>

<details>
<summary>Video: After changes</summary>

https://github.com/user-attachments/assets/ed0aef64-8f47-4b8f-a7fe-886d0b4efa90


</details>

## Notes

Blacklight will look to see if the facet has at least limit + 1 items when determining if the "more" option should be displayed.

The Solr fields with the suffix `_sim` should be used in the `config.add_facet_field` ad can be renamed using the label attribute.