### PR TITLE
Generate solr field methods

### DIFF
--- a/app/indexers/allinson_flex/dynamic_indexer_behavior.rb
+++ b/app/indexers/allinson_flex/dynamic_indexer_behavior.rb
@@ -40,7 +40,7 @@ module AllinsonFlex
         end
 
         SolrDocument.blacklight_mappings.each do |index_field_name|
-          values = convert_uri_to_value(SolrDocument.send("#{index_field_name}_fields"), found_mappings: found_mappings)
+          values = convert_uri_to_value(SolrDocument.try("#{index_field_name}_fields"), found_mappings: found_mappings)
           solr_doc["#{index_field_name}_sim"] = solr_doc["#{index_field_name}_tesim"] = values
         end
       end

--- a/app/indexers/allinson_flex/dynamic_indexer_behavior.rb
+++ b/app/indexers/allinson_flex/dynamic_indexer_behavior.rb
@@ -25,14 +25,23 @@ module AllinsonFlex
       uri_properties = uri_properties_from(dynamic_schema_service)
 
       super.tap do |solr_doc|
+        found_mappings = {}
+
         dynamic_schema_service.indexing_properties.each_pair do |prop_name, index_field_names|
+          prop_value = object.send(prop_name)
           value = if uri_properties.include?(prop_name.to_s)
-                    uri_to_value_for(object.send(prop_name))
+                    string_value = uri_to_value_for(prop_value)
+                    found_mappings[prop_name] = string_value if string_value.present?
                   else
-                    object.send(prop_name)
+                    prop_value
                   end
 
-          index_field_names.each { |index_field_name| solr_doc[index_field_name] = value }
+          index_field_names.each { |index_field_name| solr_doc[index_field_name] = value } if value.present?
+        end
+
+        SolrDocument.blacklight_mappings.each do |index_field_name|
+          values = convert_uri_to_value(SolrDocument.send("#{index_field_name}_fields"), found_mappings: found_mappings)
+          solr_doc["#{index_field_name}_sim"] = solr_doc["#{index_field_name}_tesim"] = values
         end
       end
     end

--- a/app/indexers/app_indexer.rb
+++ b/app/indexers/app_indexer.rb
@@ -14,9 +14,6 @@ class AppIndexer < Hyrax::WorkIndexer
   # Uncomment this block if you want to add custom indexing behavior:
   def generate_solr_document
     super.tap do |solr_doc|
-      solr_doc["creator_sim"] = convert_uri_to_value(SolrDocument.creator_fields)
-      solr_doc["language_sim"] = solr_doc["language_tesim"] = convert_uri_to_value(["language"])
-      solr_doc["language_local_sim"] = solr_doc["language_local_tesim"] = convert_uri_to_value(["language"])
       solr_doc["account_cname_tesim"] = Site.instance&.account&.cname
       solr_doc["bulkrax_identifier_ssim"] = object.bulkrax_identifier
       # tesim is the wrong field for this, but until we reindex everything we need to keep it

--- a/app/indexers/collection_indexer.rb
+++ b/app/indexers/collection_indexer.rb
@@ -9,8 +9,8 @@ class CollectionIndexer < Hyrax::CollectionIndexer
   # Uncomment this block if you want to add custom indexing behavior:
   def generate_solr_document
     super.tap do |solr_doc|
-      solr_doc["creator_sim"] = solr_doc["creator_tesim"] = convert_uri_to_value(SolrDocument.creator_fields)
-      solr_doc["subject_sim"] = solr_doc["subject_tesim"] = convert_uri_to_value(['subject'])
+      solr_doc["creator_sim"] = solr_doc["creator_tesim"] = convert_uri_to_value(SolrDocument.try(:creator_fields))
+      solr_doc["subject_sim"] = solr_doc["subject_tesim"] = convert_uri_to_value(SolrDocument.try(:subject_fields))
       solr_doc["contributor_sim"] = solr_doc["contributor_tesim"] = convert_uri_to_value(['contributor'])
       solr_doc["language_sim"] = solr_doc["language_tesim"] = convert_uri_to_value(['language'])
       solr_doc["bulkrax_identifier_sim"] = object.bulkrax_identifier

--- a/app/indexers/uri_to_string_behavior.rb
+++ b/app/indexers/uri_to_string_behavior.rb
@@ -9,13 +9,21 @@ module UriToStringBehavior
   # Converts URIs to their corresponding values for a list of fields.
   #
   # @param fields [Array<Symbol>] list of property names to process
+  # @param found_mappings [Hash] cache of previously resolved URI values to avoid redundant HTTP requests
   # @return [Array<String>] flattened array of resolved values with blanks removed
   #
-  # @example
+  # @example Without cache
   #   convert_uri_to_value(['creator', 'contributor'])
-  #   #=> ["University of Tennessee", "John Die"]
-  def convert_uri_to_value(fields)
-    fields.map { |prop| uri_to_value_for(object.try(prop)) }.flatten.compact
+  #   #=> ["University of Tennessee", "John Doe"]
+  #
+  # @example With cached values
+  #   mappings = { creator: ["University of Tennessee"] }
+  #   convert_uri_to_value(['creator', 'contributor'], found_mappings: mappings)
+  #   #=> ["University of Tennessee", "John Doe"] # creator used cache, contributor made HTTP request
+  def convert_uri_to_value(fields, found_mappings: {})
+    fields.flat_map do |prop|
+      found_mappings[prop.to_sym] || uri_to_value_for(object.try(prop))
+    end.compact
   end
 
   # Retrieves a value for a given URI.

--- a/app/indexers/uri_to_string_behavior.rb
+++ b/app/indexers/uri_to_string_behavior.rb
@@ -21,6 +21,8 @@ module UriToStringBehavior
   #   convert_uri_to_value(['creator', 'contributor'], found_mappings: mappings)
   #   #=> ["University of Tennessee", "John Doe"] # creator used cache, contributor made HTTP request
   def convert_uri_to_value(fields, found_mappings: {})
+    return [] if fields.blank?
+
     fields.flat_map do |prop|
       found_mappings[prop.to_sym] || uri_to_value_for(object.try(prop))
     end.compact

--- a/app/models/solr_endpoint.rb
+++ b/app/models/solr_endpoint.rb
@@ -25,6 +25,7 @@ class SolrEndpoint < Endpoint
     ActiveFedora::SolrService.instance.conn = connection
     Blacklight.connection_config = connection_options
     Blacklight.default_index = nil
+    SolrDocument.generate_field_methods
     SolrDocument.field_semantics
   end
 


### PR DESCRIPTION
## 🧹 Improve aggregating solr fields

2cc204343eeec476a4f329561629e33801d337d4

In UTK's m3 profile (looking at the YAML), we have something that looks
like: `properties[property_name]['mappings']['blacklight']`.  The value
is used to indicate what properties should be aggregated into what solr
field.  For example, `properties.photographer.mappings.blacklight` is
`creator_sim`.  That means when we have the facet drop down in the
catalog page, the photographer name should be in the `Creator` facet.
Previously, we created a method called SolrDocument.creator_fields,
which returned all properties that has `creator_sim` in the
`...mappings.blacklight`.  This commit will create a way for these
fields (only dealing with sim) to be auto generated and indexed
accordingly.

## 🧹Remove redundent indexing from AppIndexer

ebc1f38d2c83f506ce2ca2bb0d166c4476808a05

This commit will remove some fields that are already being indexed in
the `AllinsonFlex::DynamicIndexerBehavior`.

## 🧹 Use subject_fields for the collection indexer

5e676e94a07e838c03ca0d6c834482e22b33609f

This commit will leverage the meta programmed methods to indexed the
fields onto the Collection.  We have to do this manually since
Collections are not supported by AllinsonFlex.
