### PR TITLE
🐛 Fix bug with updating the schema

### DIFF
--- a/app/indexers/allinson_flex/dynamic_indexer_behavior.rb
+++ b/app/indexers/allinson_flex/dynamic_indexer_behavior.rb
@@ -21,7 +21,7 @@ module AllinsonFlex
     end
 
     def generate_solr_document
-      dynamic_schema_service = object.dynamic_schema_service
+      dynamic_schema_service = object.dynamic_schema_service(update: true)
       uri_properties = uri_properties_from(dynamic_schema_service)
 
       super.tap do |solr_doc|


### PR DESCRIPTION
Prior, if we changed any of properties from the m3 profile.  The work would not be able to update. That's because when we get into the `AllinsonFlex::DynamicIndexerBehavior#generate_solr_document`, the object's `dynamic_schmea_service` would return the version of the schema that the object was made with.  So at the time, for example, if we had a property named `foo` and then later changed it to `baz`, we should be looking for a method called `foo` still and wind up with a NoMethodError because in the current schema, `foo` no longer exists.  Also, the `baz` property would never get indexed because that did not exist in the previous schema.  By adding the `update: true` to the `#dynamic_schema_service`, we look at the current version of the schema.
