### PR TITLE
🐛 Add a try for :creator_fields

### DIFF
--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -151,7 +151,7 @@ class SolrDocument
         #                      :format, :identifier, :language, :publisher, :relation,
         #                      :rights, :source, :subject, :title, :type]
         {
-          creator: creator_fields.map { |field| field + '_tesim' },
+          creator: try(:creator_fields)&.map { |field| field + '_tesim' },
           date: ['date_created_d_tesim', 'date_issued_d_tesim'],
           description: 'abstract_tesim',
           format: ['form_tesim', 'form_local_tesim', 'extent_tesim'],


### PR DESCRIPTION
This commit will fix a bug for new tenants that don't have their metadata profile set yet.  The `SolrDocument.creator_fields` method gets set dynamically based off the metadata profile so it would break if there isn't a profile.
