### PR TITLE
🐛 Fix a variable that was not found

### DIFF
--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -129,7 +129,7 @@ class SolrDocument
         begin
           @profile ||= AllinsonFlex::Profile.current_version
         rescue ActiveRecord::StatementInvalid
-          return fields
+          return []
         end
 
         return [] if @profile.blank?


### PR DESCRIPTION
During a previous refactor the `fields` variable was no longer in the same scope.  It is however just an empty array so we can substitute that in this commit.
