### PR TITLE
🧹 Remove grouped property fields from show page

### DIFF
--- a/app/services/allinson_flex/dynamic_schema_service_decorator.rb
+++ b/app/services/allinson_flex/dynamic_schema_service_decorator.rb
@@ -1,12 +1,36 @@
 # frozen_string_literal: true
 
 # OVERRIDE AllinsonFlex main: c6ec00e to add "title" as a required field
+# OVERRIDE AllinsonFlex to add grouped key for the view_properties
 module AllinsonFlex
   module DynamicSchemaServiceDecorator
     # OVERRIDE AllinsonFlex main: c6ec00e to add "title" as a required field
     # despite whether it's in the metadata profile due to validations on models
     def required_properties
       ([:title] + property_keys.map { |prop| required_for(prop) }.compact).uniq
+    end
+
+    # Pass grouped key to the view used in the attribute_rows partial
+    def view_properties
+      property_keys.map do |prop|
+        { prop => { label: property_locale(prop, 'label'),
+                    admin_only: admin_only_for(prop),
+                    grouped: grouped_property(prop) } }
+      end.inject(:merge)
+    end
+
+    def grouped_property(value)
+      # UTK uses the mappings -> blacklight field to denote which fields are grouped
+      mappings = properties[value][:mappings]
+      return false if mappings.blank?
+
+      blacklight_mapping = JSON.parse(mappings.gsub('=>', ':'))['blacklight']
+      return false if blacklight_mapping.blank?
+
+      # Only should work on multi valued properties and not the property everything groups into
+      #  ex. `creator` also has mappings -> blacklight of `creator_sim`, but we do want to show
+      #      this one on the show page.
+      blacklight_mapping.ends_with?('_sim') && blacklight_mapping.split('_').first != value.to_s
     end
   end
 end

--- a/app/views/themes/dc_show/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/themes/dc_show/hyrax/base/_attribute_rows.html.erb
@@ -4,6 +4,7 @@
   <%# @todo internationalisation %>
   <% next if Rails.configuration.hidden_properties.include?(prop_key) %>
   <% next if prop_value[:admin_only] && !presenter.current_ability.current_user.admin? %>
+  <% next if prop_value[:grouped] %>
   <%# Only rights_statement and license have special render_as options %>
   <% value = if [:rights_statement, :license].include? prop_key %>
     <% presenter.attribute_to_html(prop_key, render_as: prop_key, html_dl: true) %>


### PR DESCRIPTION
This commit will add logic to prevent grouped properties from displaying on the work show page since the field that they are grouped into is already displaying the value.

Ref:
- https://github.com/notch8/utk-hyku/issues/637

## Before
Has `author`, `artist`, and extra `location` and `creator`
![image](https://github.com/user-attachments/assets/f5782a4b-e88e-457f-8ed0-0e409078943e)

## After
They are no longer displaying
![image](https://github.com/user-attachments/assets/15c80318-ae5a-4cbc-95ad-8ef7d72e87b9)
