### PR TITLE
💄 Turn accouncement text white

### DIFF
--- a/app/assets/stylesheets/utk-overrides.scss
+++ b/app/assets/stylesheets/utk-overrides.scss
@@ -16,3 +16,9 @@ body.public-facing.utk-public-facing {
     border-bottom: none;
   }
 }
+
+#announcement {
+  p {
+    color: inherit;
+  }
+}


### PR DESCRIPTION
This commit will turn the accouncement text white for better contrast.

Ref:
- https://github.com/notch8/utk-hyku/issues/681

<img width="1128" alt="image" src="https://github.com/user-attachments/assets/81f6a622-8818-4077-bc90-279262439f5f" />
