### PR TITLE
⚙️ Remove download button from Universal Viewer

### DIFF
--- a/config/uv/uv-config.json
+++ b/config/uv/uv-config.json
@@ -1,3 +1,9 @@
 {
-  
+  "modules": {
+    "footerPanel": {
+      "options": {
+        "downloadEnabled": false
+      }
+    }
+  }
 }


### PR DESCRIPTION
This commit will remove the download button from the UV.  Ideally, we would have liked to hide the confined download option however it doesn't seem like there's a clear way to do that for v3.1.4 of the Univeral Viewer.

Ref:
- https://github.com/notch8/utk-hyku/issues/643

<img width="390" alt="image" src="https://github.com/user-attachments/assets/2372b0bc-5640-4646-99c4-f396ab1bae15" />
