### PR TITLE
🧹 Improve LOC language check

### DIFF
--- a/app/indexers/uri_to_string_behavior.rb
+++ b/app/indexers/uri_to_string_behavior.rb
@@ -61,7 +61,9 @@ module UriToStringBehavior
 
     subject = RDF::URI.new(subject_uri)
     objects = graph.query([subject, predicate, nil]).objects
-    object = objects.find { |o| o.language == :en || o.language == :'en-us' } || objects.first
+    object = objects.find do |o|
+      o.language == :en || o.language == :'en-us' || o.language.nil?
+    end || objects.sort_by(&:value).first
     return "#{uri} (No label found)" if object.blank?
 
     object.to_s

--- a/spec/fixtures/rdf_data/loc.nt
+++ b/spec/fixtures/rdf_data/loc.nt
@@ -1,58 +1,1736 @@
-<http://id.loc.gov/vocabulary/iso639-2/eng> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Language> .
-<http://id.loc.gov/vocabulary/iso639-2/eng> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <//www.loc.gov/mads/rdf/v1#Authority> .
-<http://id.loc.gov/vocabulary/iso639-2/eng> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/vocabulary/iso639-2/iso639-2_Language> .
-<http://id.loc.gov/vocabulary/iso639-2/eng> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "English"@en .
-<http://id.loc.gov/vocabulary/iso639-2/eng> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "anglais"@fr .
-<http://id.loc.gov/vocabulary/iso639-2/eng> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Englisch"@de .
-<http://id.loc.gov/vocabulary/iso639-2/eng> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b13iddOtlocdOtgovvocabularyiso639-2eng .
-_:b13iddOtlocdOtgovvocabularyiso639-2eng <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Language> .
-_:b13iddOtlocdOtgovvocabularyiso639-2eng <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <//www.loc.gov/mads/rdf/v1#Variant> .
-_:b13iddOtlocdOtgovvocabularyiso639-2eng <http://www.loc.gov/mads/rdf/v1#variantLabel> "English"@en .
-<http://id.loc.gov/vocabulary/iso639-2/eng> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b23iddOtlocdOtgovvocabularyiso639-2eng .
-_:b23iddOtlocdOtgovvocabularyiso639-2eng <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Language> .
-_:b23iddOtlocdOtgovvocabularyiso639-2eng <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <//www.loc.gov/mads/rdf/v1#Variant> .
-_:b23iddOtlocdOtgovvocabularyiso639-2eng <http://www.loc.gov/mads/rdf/v1#variantLabel> "anglais"@fr .
-<http://id.loc.gov/vocabulary/iso639-2/eng> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b33iddOtlocdOtgovvocabularyiso639-2eng .
-_:b33iddOtlocdOtgovvocabularyiso639-2eng <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Language> .
-_:b33iddOtlocdOtgovvocabularyiso639-2eng <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <//www.loc.gov/mads/rdf/v1#Variant> .
-_:b33iddOtlocdOtgovvocabularyiso639-2eng <http://www.loc.gov/mads/rdf/v1#variantLabel> "Englisch"@de .
-<http://id.loc.gov/vocabulary/iso639-2/eng> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/iso639-2/collection_iso639-2_Bibliographic_Codes> .
-<http://id.loc.gov/vocabulary/iso639-2/eng> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/iso639-2/collection_PastPresentISO639-2Entries> .
-<http://id.loc.gov/vocabulary/iso639-2/eng> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/vocabulary/iso639-2/collection_iso639-2> .
-<http://id.loc.gov/vocabulary/iso639-2/eng> <http://www.loc.gov/mads/rdf/v1#hasExactExternalAuthority> <http://id.loc.gov/vocabulary/languages/eng> .
-<http://id.loc.gov/vocabulary/iso639-2/eng> <http://www.loc.gov/mads/rdf/v1#hasExactExternalAuthority> <http://id.loc.gov/vocabulary/iso639-1/en> .
-<http://id.loc.gov/vocabulary/iso639-2/eng> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/vocabulary/iso639-2> .
-<http://id.loc.gov/vocabulary/iso639-2/eng> <http://www.loc.gov/mads/rdf/v1#note> "Bibliographic Code"@en .
-<http://id.loc.gov/vocabulary/iso639-2/eng> <http://www.loc.gov/mads/rdf/v1#code> "eng"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://id.loc.gov/vocabulary/iso639-2/eng> <http://www.loc.gov/mads/rdf/v1#adminMetadata> _:b53iddOtlocdOtgovvocabularyiso639-2eng .
-_:b53iddOtlocdOtgovvocabularyiso639-2eng <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/RecordInfo#RecordInfo> .
-_:b53iddOtlocdOtgovvocabularyiso639-2eng <http://id.loc.gov/ontologies/RecordInfo#recordChangeDate> "1970-01-01T00:00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
-_:b53iddOtlocdOtgovvocabularyiso639-2eng <http://id.loc.gov/ontologies/RecordInfo#recordStatus> "new"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b53iddOtlocdOtgovvocabularyiso639-2eng <http://id.loc.gov/ontologies/RecordInfo#recordContentSource> <http://id.loc.gov/vocabulary/organizations/dlc> .
-<http://id.loc.gov/vocabulary/iso639-2/eng> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<http://id.loc.gov/vocabulary/iso639-2/eng> <http://www.w3.org/2004/02/skos/core#prefLabel> "English"@en .
-<http://id.loc.gov/vocabulary/iso639-2/eng> <http://www.w3.org/2004/02/skos/core#prefLabel> "anglais"@fr .
-<http://id.loc.gov/vocabulary/iso639-2/eng> <http://www.w3.org/2004/02/skos/core#prefLabel> "Englisch"@de .
-<http://id.loc.gov/vocabulary/iso639-2/eng> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b72iddOtlocdOtgovvocabularyiso639-2eng .
-_:b72iddOtlocdOtgovvocabularyiso639-2eng <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
-_:b72iddOtlocdOtgovvocabularyiso639-2eng <http://www.w3.org/2008/05/skos-xl#literalForm> "English"@en .
-<http://id.loc.gov/vocabulary/iso639-2/eng> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b77iddOtlocdOtgovvocabularyiso639-2eng .
-_:b77iddOtlocdOtgovvocabularyiso639-2eng <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
-_:b77iddOtlocdOtgovvocabularyiso639-2eng <http://www.w3.org/2008/05/skos-xl#literalForm> "anglais"@fr .
-<http://id.loc.gov/vocabulary/iso639-2/eng> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b82iddOtlocdOtgovvocabularyiso639-2eng .
-_:b82iddOtlocdOtgovvocabularyiso639-2eng <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
-_:b82iddOtlocdOtgovvocabularyiso639-2eng <http://www.w3.org/2008/05/skos-xl#literalForm> "Englisch"@de .
-<http://id.loc.gov/vocabulary/iso639-2/eng> <http://www.w3.org/2004/02/skos/core#exactMatch> <http://id.loc.gov/vocabulary/languages/eng> .
-<http://id.loc.gov/vocabulary/iso639-2/eng> <http://www.w3.org/2004/02/skos/core#exactMatch> <http://id.loc.gov/vocabulary/iso639-1/en> .
-<http://id.loc.gov/vocabulary/iso639-2/eng> <http://www.w3.org/2004/02/skos/core#note> "Bibliographic Code"@en .
-<http://id.loc.gov/vocabulary/iso639-2/eng> <http://www.w3.org/2004/02/skos/core#notation> "eng"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://id.loc.gov/vocabulary/iso639-2/eng> <http://www.w3.org/2004/02/skos/core#inScheme> <http://id.loc.gov/vocabulary/iso639-2> .
-<http://id.loc.gov/vocabulary/iso639-2/eng> <http://www.w3.org/2004/02/skos/core#altLabel> "English"@en .
-<http://id.loc.gov/vocabulary/iso639-2/eng> <http://www.w3.org/2004/02/skos/core#altLabel> "anglais"@fr .
-<http://id.loc.gov/vocabulary/iso639-2/eng> <http://www.w3.org/2004/02/skos/core#altLabel> "Englisch"@de .
-<http://id.loc.gov/vocabulary/iso639-2/eng> <http://www.w3.org/2004/02/skos/core#changeNote> _:b100iddOtlocdOtgovvocabularyiso639-2eng .
-_:b100iddOtlocdOtgovvocabularyiso639-2eng <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/vocab/changeset/schema#ChangeSet> .
-_:b100iddOtlocdOtgovvocabularyiso639-2eng <http://purl.org/vocab/changeset/schema#subjectOfChange> <http://id.loc.gov/vocabulary/iso639-2/eng> .
-_:b100iddOtlocdOtgovvocabularyiso639-2eng <http://purl.org/vocab/changeset/schema#creatorName> <http://id.loc.gov/vocabulary/organizations/dlc> .
-_:b100iddOtlocdOtgovvocabularyiso639-2eng <http://purl.org/vocab/changeset/schema#createdDate> "1970-01-01T00:00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
-_:b100iddOtlocdOtgovvocabularyiso639-2eng <http://purl.org/vocab/changeset/schema#changeReason> "new"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "New York (N.Y.)" .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Нью Йорк балhсн (N.Y.)"@zxx-Cyrl .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "סיבֿדאד די מואיבֿה יורק (N.Y.)"@zxx-Hebr .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "نيويورك (N.Y.)"@zxx-Arab .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "ニューヨーク市 (N.Y.)"@zxx-Jpan .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Νέα Υόρκη (N.Y.)"@zxx-Grek .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "뉴욕 (N.Y.)"@zxx-Hang .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#elementList> _:b19iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b19iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b20iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b19iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b20iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b20iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "New York (N.Y.)" .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b23iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b23iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b23iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b23iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "New York (City)"@zxx-Latn .
+_:b23iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b28iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b28iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b29iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b28iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b29iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b29iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "New York (City)" .
+_:b23iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $wnnaa$aNew York (City)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b34iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b34iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b34iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b34iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Ni︠u︡ Ĭork (N.Y.)"@zxx-Latn .
+_:b34iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b39iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b39iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b40iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b39iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b40iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b40iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "Ni︠u︡ Ĭork (N.Y.)" .
+_:b34iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aNi︠u︡ Ĭork (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b45iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b45iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b45iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b45iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Novi Jork (N.Y.)"@zxx-Latn .
+_:b45iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b50iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b50iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b51iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b50iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b51iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b51iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "Novi Jork (N.Y.)" .
+_:b45iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aNovi Jork (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b56iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b56iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b56iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b56iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Nova Iorque (N.Y.)"@zxx-Latn .
+_:b56iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b61iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b61iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b62iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b61iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b62iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b62iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "Nova Iorque (N.Y.)" .
+_:b56iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aNova Iorque (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b67iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b67iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b67iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b67iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Nyu-Yorḳ (N.Y.)"@zxx-Latn .
+_:b67iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b72iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b72iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b73iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b72iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b73iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b73iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "Nyu-Yorḳ (N.Y.)" .
+_:b67iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aNyu-Yorḳ (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b78iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b78iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b78iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b78iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Nueva York (N.Y.)"@zxx-Latn .
+_:b78iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b83iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b83iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b84iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b83iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b84iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b84iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "Nueva York (N.Y.)" .
+_:b78iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aNueva York (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b89iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b89iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b89iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b89iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Nu Yorḳ (N.Y.)"@zxx-Latn .
+_:b89iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b94iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b94iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b95iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b94iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b95iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b95iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "Nu Yorḳ (N.Y.)" .
+_:b89iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aNu Yorḳ (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b100iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b100iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b100iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b100iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Nyuyok (N.Y.)"@zxx-Latn .
+_:b100iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b105iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b105iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b106iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b105iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b106iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b106iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "Nyuyok (N.Y.)" .
+_:b100iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aNyuyok (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b111iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b111iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b111iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b111iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Nuyorḳ (N.Y.)"@zxx-Latn .
+_:b111iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b116iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b116iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b117iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b116iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b117iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b117iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "Nuyorḳ (N.Y.)" .
+_:b111iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aNuyorḳ (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b122iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b122iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b122iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b122iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "New York City (N.Y.)"@zxx-Latn .
+_:b122iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b127iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b127iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b128iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b127iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b128iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b128iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "New York City (N.Y.)" .
+_:b122iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aNew York City (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b133iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b133iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b133iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b133iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Niyū Yūrk (N.Y.)"@zxx-Latn .
+_:b133iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b138iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b138iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b139iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b138iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b139iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b139iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "Niyū Yūrk (N.Y.)" .
+_:b133iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aNiyū Yūrk (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b144iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b144iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b144iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b144iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Niyūyūrk (N.Y.)"@zxx-Latn .
+_:b144iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b149iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b149iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b150iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b149iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b150iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b150iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "Niyūyūrk (N.Y.)" .
+_:b144iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aNiyūyūrk (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b155iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b155iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b155iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b155iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Niu-yüeh (N.Y.)"@zxx-Latn .
+_:b155iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b160iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b160iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b161iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b160iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b161iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b161iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "Niu-yüeh (N.Y.)" .
+_:b155iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aNiu-yüeh (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b166iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b166iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b166iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b166iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Nowy Jork (N.Y.)"@zxx-Latn .
+_:b166iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b171iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b171iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b172iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b171iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b172iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b172iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "Nowy Jork (N.Y.)" .
+_:b166iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aNowy Jork (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b177iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b177iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#CorporateName> .
+_:b177iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b177iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Corporation of the City of New York (N.Y.)"@zxx-Latn .
+_:b177iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b182iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b182iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b183iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b182iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b183iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#NameElement> .
+_:b183iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "Corporation of the City of New York (N.Y.)" .
+_:b177iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "4102 $aCorporation of the City of New York (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b188iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b188iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b188iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b188iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "City of New York (N.Y.)"@zxx-Latn .
+_:b188iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b193iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b193iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b194iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b193iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b194iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b194iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "City of New York (N.Y.)" .
+_:b188iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aCity of New York (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b199iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b199iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b199iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b199iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "New York Stad (N.Y.)"@zxx-Latn .
+_:b199iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b204iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b204iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b205iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b204iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b205iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b205iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "New York Stad (N.Y.)" .
+_:b199iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aNew York Stad (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b210iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b210iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b210iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b210iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "نيويورك (N.Y.)"@zxx-Arab .
+_:b210iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b215iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b215iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b216iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b215iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b216iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b216iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "نيويورك (N.Y.)" .
+_:b210iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aنيويورك (N.Y.)"@zxx-Arab .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b221iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b221iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b221iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b221iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Táva Nueva York (N.Y.)"@zxx-Latn .
+_:b221iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b226iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b226iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b227iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b226iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b227iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b227iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "Táva Nueva York (N.Y.)" .
+_:b221iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aTáva Nueva York (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b232iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b232iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b232iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b232iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Nyu-York Şähäri (N.Y.)"@zxx-Latn .
+_:b232iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b237iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b237iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b238iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b237iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b238iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b238iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "Nyu-York Şähäri (N.Y.)" .
+_:b232iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aNyu-York Şähäri (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b243iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b243iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b243iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b243iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Нью-Йорк (N.Y.)"@zxx-Cyrl .
+_:b243iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b248iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b248iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b249iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b248iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b249iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b249iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "Нью-Йорк (N.Y.)" .
+_:b243iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aНью-Йорк (N.Y.)"@zxx-Cyrl .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b254iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b254iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b254iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b254iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Горад Нью-Ёрк (N.Y.)"@zxx-Cyrl .
+_:b254iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b259iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b259iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b260iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b259iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b260iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b260iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "Горад Нью-Ёрк (N.Y.)" .
+_:b254iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aГорад Нью-Ёрк (N.Y.)"@zxx-Cyrl .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b265iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b265iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b265iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b265iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Horad Nʹi︠u︡-I︠O︡rk (N.Y.)"@zxx-Latn .
+_:b265iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b270iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b270iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b271iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b270iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b271iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b271iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "Horad Nʹi︠u︡-I︠O︡rk (N.Y.)" .
+_:b265iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aHorad Nʹi︠u︡-I︠O︡rk (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b276iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b276iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b276iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b276iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Нью-Ёрк (N.Y.)"@zxx-Cyrl .
+_:b276iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b281iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b281iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b282iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b281iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b282iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b282iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "Нью-Ёрк (N.Y.)" .
+_:b276iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aНью-Ёрк (N.Y.)"@zxx-Cyrl .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b287iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b287iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b287iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b287iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Ню Йорк (N.Y.)"@zxx-Cyrl .
+_:b287iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b292iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b292iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b293iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b292iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b293iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b293iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "Ню Йорк (N.Y.)" .
+_:b287iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aНю Йорк (N.Y.)"@zxx-Cyrl .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b298iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b298iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b298iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b298iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Nova York (N.Y.)"@zxx-Latn .
+_:b298iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b303iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b303iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b304iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b303iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b304iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b304iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "Nova York (N.Y.)" .
+_:b298iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aNova York (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b309iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b309iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b309iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b309iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Çĕнĕ Йорк (N.Y.)"@zxx-Cyrl .
+_:b309iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b314iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b314iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b315iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b314iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b315iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b315iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "Çĕнĕ Йорк (N.Y.)" .
+_:b309iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aÇĕнĕ Йорк (N.Y.)"@zxx-Cyrl .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b320iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b320iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b320iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b320iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Śĕnĕ Ĭork (N.Y.)"@zxx-Latn .
+_:b320iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b325iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b325iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b326iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b325iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b326iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b326iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "Śĕnĕ Ĭork (N.Y.)" .
+_:b320iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aŚĕnĕ Ĭork (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b331iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b331iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b331iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b331iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Dakbayan sa New York (N.Y.)"@zxx-Latn .
+_:b331iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b336iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b336iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b337iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b336iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b337iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b337iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "Dakbayan sa New York (N.Y.)" .
+_:b331iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aDakbayan sa New York (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b342iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b342iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b342iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b342iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Dinas Efrog Newydd (N.Y.)"@zxx-Latn .
+_:b342iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b347iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b347iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b348iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b347iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b348iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b348iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "Dinas Efrog Newydd (N.Y.)" .
+_:b342iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aDinas Efrog Newydd (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b353iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b353iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b353iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b353iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Efrog Newydd (N.Y.)"@zxx-Latn .
+_:b353iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b358iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b358iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b359iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b358iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b359iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b359iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "Efrog Newydd (N.Y.)" .
+_:b353iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aEfrog Newydd (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b364iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b364iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b364iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b364iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Nei Yarrick Schtadt (N.Y.)"@zxx-Latn .
+_:b364iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b369iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b369iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b370iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b369iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b370iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b370iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "Nei Yarrick Schtadt (N.Y.)" .
+_:b364iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aNei Yarrick Schtadt (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b375iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b375iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b375iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b375iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Nei Yarrick (N.Y.)"@zxx-Latn .
+_:b375iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b380iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b380iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b381iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b380iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b381iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b381iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "Nei Yarrick (N.Y.)" .
+_:b375iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aNei Yarrick (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b386iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b386iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b386iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b386iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Νέα Υόρκη (N.Y.)"@zxx-Grek .
+_:b386iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b391iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b391iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b392iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b391iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b392iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b392iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "Νέα Υόρκη (N.Y.)" .
+_:b386iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aΝέα Υόρκη (N.Y.)"@zxx-Grek .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b397iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b397iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b397iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b397iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Nea Yorkē (N.Y.)"@zxx-Latn .
+_:b397iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b402iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b402iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b403iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b402iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b403iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b403iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "Nea Yorkē (N.Y.)" .
+_:b397iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aNea Yorkē (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b408iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b408iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b408iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b408iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Ciudad de Nueva York (N.Y.)"@zxx-Latn .
+_:b408iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b413iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b413iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b414iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b413iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b414iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b414iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "Ciudad de Nueva York (N.Y.)" .
+_:b408iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aCiudad de Nueva York (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b419iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b419iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b419iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b419iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Novjorko (N.Y.)"@zxx-Latn .
+_:b419iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b424iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b424iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b425iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b424iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b425iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b425iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "Novjorko (N.Y.)" .
+_:b419iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aNovjorko (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b430iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b430iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b430iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b430iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Nouvelle York (N.Y.)"@zxx-Latn .
+_:b430iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b435iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b435iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b436iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b435iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b436iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b436iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "Nouvelle York (N.Y.)" .
+_:b430iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aNouvelle York (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b441iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b441iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b441iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b441iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Nua-Eabhrac (N.Y.)"@zxx-Latn .
+_:b441iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b446iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b446iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b447iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b446iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b447iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b447iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "Nua-Eabhrac (N.Y.)" .
+_:b441iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aNua-Eabhrac (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b452iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b452iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b452iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b452iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Cathair Nua-Eabhrac (N.Y.)"@zxx-Latn .
+_:b452iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b457iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b457iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b458iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b457iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b458iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b458iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "Cathair Nua-Eabhrac (N.Y.)" .
+_:b452iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aCathair Nua-Eabhrac (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b463iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b463iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b463iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b463iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Caayr York Noa (N.Y.)"@zxx-Latn .
+_:b463iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b468iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b468iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b469iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b468iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b469iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b469iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "Caayr York Noa (N.Y.)" .
+_:b463iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aCaayr York Noa (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b474iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b474iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b474iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b474iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "York Noa (N.Y.)"@zxx-Latn .
+_:b474iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b479iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b479iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b480iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b479iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b480iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b480iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "York Noa (N.Y.)" .
+_:b474iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aYork Noa (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b485iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b485iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b485iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b485iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Eabhraig Nuadh (N.Y.)"@zxx-Latn .
+_:b485iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b490iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b490iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b491iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b490iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b491iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b491iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "Eabhraig Nuadh (N.Y.)" .
+_:b485iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aEabhraig Nuadh (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b496iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b496iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b496iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b496iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Baile Eabhraig Nuadh (N.Y.)"@zxx-Latn .
+_:b496iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b501iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b501iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b502iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b501iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b502iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b502iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "Baile Eabhraig Nuadh (N.Y.)" .
+_:b496iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aBaile Eabhraig Nuadh (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b507iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b507iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b507iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b507iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Нью Йорк балhсн (N.Y.)"@zxx-Cyrl .
+_:b507iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b512iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b512iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b513iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b512iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b513iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b513iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "Нью Йорк балhсн (N.Y.)" .
+_:b507iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aНью Йорк балhсн (N.Y.)"@zxx-Cyrl .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b518iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b518iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b518iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b518iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Nʹi︠u︡ Ĭork balḣsn (N.Y.)"@zxx-Latn .
+_:b518iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b523iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b523iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b524iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b523iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b524iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b524iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "Nʹi︠u︡ Ĭork balḣsn (N.Y.)" .
+_:b518iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aNʹi︠u︡ Ĭork balḣsn (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b529iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b529iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b529iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b529iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Шин Йорк (N.Y.)"@zxx-Cyrl .
+_:b529iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b534iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b534iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b535iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b534iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b535iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b535iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "Шин Йорк (N.Y.)" .
+_:b529iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aШин Йорк (N.Y.)"@zxx-Cyrl .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b540iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b540iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b540iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b540iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Shin Ĭork (N.Y.)"@zxx-Latn .
+_:b540iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b545iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b545iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b546iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b545iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b546iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b546iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "Shin Ĭork (N.Y.)" .
+_:b540iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aShin Ĭork (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b551iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b551iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b551iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b551iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "뉴욕 (N.Y.)"@zxx-Hang .
+_:b551iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b556iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b556iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b557iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b556iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b557iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b557iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "뉴욕 (N.Y.)" .
+_:b551iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $a뉴욕 (N.Y.)"@zxx-Hang .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b562iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b562iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b562iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b562iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Lungsod ng New York (N.Y.)"@zxx-Latn .
+_:b562iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b567iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b567iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b568iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b567iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b568iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b568iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "Lungsod ng New York (N.Y.)" .
+_:b562iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aLungsod ng New York (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b573iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b573iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b573iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b573iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Tchiaq York Iniqpak (N.Y.)"@zxx-Latn .
+_:b573iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b578iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b578iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b579iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b578iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b579iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b579iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "Tchiaq York Iniqpak (N.Y.)" .
+_:b573iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aTchiaq York Iniqpak (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b584iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b584iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b584iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b584iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Tchiaq York (N.Y.)"@zxx-Latn .
+_:b584iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b589iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b589iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b590iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b589iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b590iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b590iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "Tchiaq York (N.Y.)" .
+_:b584iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aTchiaq York (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b595iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b595iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b595iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b595iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "New York-borg (N.Y.)"@zxx-Latn .
+_:b595iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b600iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b600iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b601iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b600iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b601iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b601iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "New York-borg (N.Y.)" .
+_:b595iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aNew York-borg (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b606iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b606iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b606iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b606iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Nuova York (N.Y.)"@zxx-Latn .
+_:b606iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b611iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b611iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b612iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b611iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b612iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b612iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "Nuova York (N.Y.)" .
+_:b606iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aNuova York (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b617iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b617iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b617iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b617iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "ניו יורק (N.Y.)"@zxx-Hebr .
+_:b617iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b622iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b622iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b623iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b622iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b623iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b623iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "ניו יורק (N.Y.)" .
+_:b617iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aניו יורק (N.Y.)"@zxx-Hebr .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b628iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b628iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b628iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b628iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "New York Lakanbalen (N.Y.)"@zxx-Latn .
+_:b628iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b633iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b633iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b634iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b633iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b634iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b634iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "New York Lakanbalen (N.Y.)" .
+_:b628iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aNew York Lakanbalen (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b639iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b639iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b639iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b639iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Lakanabalen ning New York (N.Y.)"@zxx-Latn .
+_:b639iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b644iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b644iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b645iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b644iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b645iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b645iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "Lakanabalen ning New York (N.Y.)" .
+_:b639iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aLakanabalen ning New York (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b650iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b650iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b650iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b650iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Evrek Nowydh (N.Y.)"@zxx-Latn .
+_:b650iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b655iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b655iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b656iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b655iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b656iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b656iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "Evrek Nowydh (N.Y.)" .
+_:b650iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aEvrek Nowydh (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b661iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b661iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b661iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b661iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Nouyòk (N.Y.)"@zxx-Latn .
+_:b661iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b666iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b666iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b667iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b666iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b667iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b667iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "Nouyòk (N.Y.)" .
+_:b661iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aNouyòk (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b672iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b672iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b672iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b672iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Bajarê New Yorkê (N.Y.)"@zxx-Latn .
+_:b672iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b677iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b677iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b678iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b677iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b678iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b678iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "Bajarê New Yorkê (N.Y.)" .
+_:b672iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aBajarê New Yorkê (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b683iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b683iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b683iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b683iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "New Yorkê (N.Y.)"@zxx-Latn .
+_:b683iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b688iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b688iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b689iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b688iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b689iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b689iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "New Yorkê (N.Y.)" .
+_:b683iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aNew Yorkê (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b694iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b694iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b694iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b694iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Mueva York (N.Y.)"@zxx-Latn .
+_:b694iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b699iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b699iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b700iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b699iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b700iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b700iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "Mueva York (N.Y.)" .
+_:b694iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aMueva York (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b705iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b705iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b705iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b705iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Sivdad de Mueva York (N.Y.)"@zxx-Latn .
+_:b705iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b710iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b710iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b711iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b710iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b711iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b711iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "Sivdad de Mueva York (N.Y.)" .
+_:b705iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aSivdad de Mueva York (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b716iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b716iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b716iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b716iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "סיבֿדאד די מואיבֿה יורק (N.Y.)"@zxx-Hebr .
+_:b716iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b721iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b721iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b722iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b721iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b722iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b722iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "סיבֿדאד די מואיבֿה יורק (N.Y.)" .
+_:b716iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aסיבֿדאד די מואיבֿה יורק (N.Y.)"@zxx-Hebr .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b727iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b727iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b727iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b727iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Sivdad de Muevah Yorḳ (N.Y.)"@zxx-Latn .
+_:b727iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b732iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b732iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b733iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b732iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b733iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b733iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "Sivdad de Muevah Yorḳ (N.Y.)" .
+_:b727iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aSivdad de Muevah Yorḳ (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b738iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b738iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b738iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b738iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "מואיבֿה יורק (N.Y.)"@zxx-Hebr .
+_:b738iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b743iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b743iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b744iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b743iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b744iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b744iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "מואיבֿה יורק (N.Y.)" .
+_:b738iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aמואיבֿה יורק (N.Y.)"@zxx-Hebr .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b749iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b749iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b749iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b749iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Muevah Yorḳ (N.Y.)"@zxx-Latn .
+_:b749iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b754iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b754iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b755iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b754iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b755iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b755iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "Muevah Yorḳ (N.Y.)" .
+_:b749iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aMuevah Yorḳ (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b760iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b760iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b760iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b760iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Novum Eboracum (N.Y.)"@zxx-Latn .
+_:b760iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b765iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b765iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b766iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b765iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b766iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b766iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "Novum Eboracum (N.Y.)" .
+_:b760iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aNovum Eboracum (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b771iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b771iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b771iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b771iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Neo-Eboracum (N.Y.)"@zxx-Latn .
+_:b771iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b776iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b776iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b777iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b776iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b777iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b777iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "Neo-Eboracum (N.Y.)" .
+_:b771iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aNeo-Eboracum (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b782iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b782iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b782iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b782iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Civitas Novi Eboraci (N.Y.)"@zxx-Latn .
+_:b782iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b787iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b787iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b788iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b787iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b788iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b788iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "Civitas Novi Eboraci (N.Y.)" .
+_:b782iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aCivitas Novi Eboraci (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b793iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b793iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b793iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b793iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Ņujorka (N.Y.)"@zxx-Latn .
+_:b793iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b798iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b798iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b799iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b798iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b799iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b799iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "Ņujorka (N.Y.)" .
+_:b793iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aŅujorka (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b804iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b804iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b804iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b804iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Niujorkas (N.Y.)"@zxx-Latn .
+_:b804iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b809iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b809iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b810iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b809iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b810iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b810iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "Niujorkas (N.Y.)" .
+_:b804iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aNiujorkas (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b815iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b815iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b815iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b815iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Niujorko miestas (N.Y.)"@zxx-Latn .
+_:b815iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b820iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b820iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b821iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b820iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b821iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b821iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "Niujorko miestas (N.Y.)" .
+_:b815iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aNiujorko miestas (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b826iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b826iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b826iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b826iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Niuiork (N.Y.)"@zxx-Latn .
+_:b826iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b831iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b831iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b832iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b831iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b832iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b832iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "Niuiork (N.Y.)" .
+_:b826iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aNiuiork (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b837iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b837iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b837iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b837iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Њујорк (N.Y.)"@zxx-Cyrl .
+_:b837iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b842iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b842iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b843iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b842iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b843iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b843iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "Њујорк (N.Y.)" .
+_:b837iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aЊујорк (N.Y.)"@zxx-Cyrl .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b848iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b848iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b848iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b848iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Njujork (N.Y.)"@zxx-Latn .
+_:b848iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b853iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b853iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b854iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b853iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b854iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b854iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "Njujork (N.Y.)" .
+_:b848iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aNjujork (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b859iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b859iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b859iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b859iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Bandar Raya New York (N.Y.)"@zxx-Latn .
+_:b859iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b864iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b864iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b865iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b864iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b865iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b865iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "Bandar Raya New York (N.Y.)" .
+_:b859iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aBandar Raya New York (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b870iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b870iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b870iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b870iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Bandaraya New York (N.Y.)"@zxx-Latn .
+_:b870iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b875iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b875iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b876iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b875iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b876iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b876iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "Bandaraya New York (N.Y.)" .
+_:b870iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aBandaraya New York (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b881iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b881iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b881iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b881iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Nuoba Iorque (N.Y.)"@zxx-Latn .
+_:b881iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b886iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b886iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b887iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b886iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b887iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b887iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "Nuoba Iorque (N.Y.)" .
+_:b881iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aNuoba Iorque (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b892iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b892iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b892iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b892iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Нью-Йорк хот (N.Y.)"@zxx-Cyrl .
+_:b892iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b897iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b897iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b898iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b897iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b898iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b898iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "Нью-Йорк хот (N.Y.)" .
+_:b892iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aНью-Йорк хот (N.Y.)"@zxx-Cyrl .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b903iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b903iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b903iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b903iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Nʹi︠u︡-Ĭork khot (N.Y.)"@zxx-Latn .
+_:b903iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b908iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b908iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b909iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b908iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b909iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b909iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "Nʹi︠u︡-Ĭork khot (N.Y.)" .
+_:b903iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aNʹi︠u︡-Ĭork khot (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b914iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b914iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b914iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b914iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Āltepētl Yancuīc York (N.Y.)"@zxx-Latn .
+_:b914iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b919iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b919iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b920iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b919iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b920iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b920iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "Āltepētl Yancuīc York (N.Y.)" .
+_:b914iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aĀltepētl Yancuīc York (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b925iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b925iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b925iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b925iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Niej-York (N.Y.)"@zxx-Latn .
+_:b925iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b930iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b930iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b931iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b930iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b931iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b931iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "Niej-York (N.Y.)" .
+_:b925iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aNiej-York (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b936iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b936iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b936iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b936iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "ニューヨーク (N.Y.)"@zxx-Jpan .
+_:b936iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b941iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b941iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b942iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b941iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b942iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b942iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "ニューヨーク (N.Y.)" .
+_:b936iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aニューヨーク (N.Y.)"@zxx-Jpan .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b947iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b947iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b947iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b947iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Nyū Yōku (N.Y.)"@zxx-Latn .
+_:b947iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b952iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b952iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b953iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b952iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b953iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b953iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "Nyū Yōku (N.Y.)" .
+_:b947iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aNyū Yōku (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b958iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b958iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b958iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b958iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "ニューヨーク市 (N.Y.)"@zxx-Jpan .
+_:b958iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b963iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b963iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b964iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b963iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b964iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b964iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "ニューヨーク市 (N.Y.)" .
+_:b958iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aニューヨーク市 (N.Y.)"@zxx-Jpan .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b969iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b969iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b969iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b969iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "Nyū Yōku-shi (N.Y.)"@zxx-Latn .
+_:b969iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b974iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b974iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b975iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b974iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b975iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b975iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "Nyū Yōku-shi (N.Y.)" .
+_:b969iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aNyū Yōku-shi (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b980iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b980iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b980iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b980iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "NYC (N.Y.)"@zxx-Latn .
+_:b980iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b985iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b985iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b986iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b985iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b986iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b986iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "NYC (N.Y.)" .
+_:b980iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aNYC (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasVariant> _:b991iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b991iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b991iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b991iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "N.Y.C. (N.Y.)"@zxx-Latn .
+_:b991iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b996iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b996iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b997iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b996iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b997iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b997iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "N.Y.C. (N.Y.)" .
+_:b991iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aN.Y.C. (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aНью Йорк балhсн (N.Y.)"@zxx-Cyrl .
+<http://id.loc.gov/authorities/names/n79007751> <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aסיבֿדאד די מואיבֿה יורק (N.Y.)"@zxx-Hebr .
+<http://id.loc.gov/authorities/names/n79007751> <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aنيويورك (N.Y.)"@zxx-Arab .
+<http://id.loc.gov/authorities/names/n79007751> <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aニューヨーク市 (N.Y.)"@zxx-Jpan .
+<http://id.loc.gov/authorities/names/n79007751> <http://id.loc.gov/ontologies/bflc/marcKey> "451 $aΝέα Υόρκη (N.Y.)"@zxx-Grek .
+<http://id.loc.gov/authorities/names/n79007751> <http://id.loc.gov/ontologies/bflc/marcKey> "451 $a뉴욕 (N.Y.)"@zxx-Hang .
+<http://id.loc.gov/authorities/names/n79007751> <http://id.loc.gov/ontologies/bflc/marcKey> "151 $aNew York (N.Y.)" .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasReciprocalAuthority> <http://id.loc.gov/authorities/names/n2019017691> .
+<http://id.loc.gov/authorities/names/n2019017691> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/authorities/names/n2019017691> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "New Amsterdam (New Netherland)" .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasEarlierEstablishedForm> _:b1020iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1020iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Geographic> .
+_:b1020iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Variant> .
+_:b1020iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#variantLabel> "New York (City)" .
+_:b1020iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementList> _:b1025iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1025iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b1026iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1025iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b1026iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#GeographicElement> .
+_:b1026iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#elementValue> "New York (City)" .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasCloseExternalAuthority> <http://datos.bne.es/resource/XX450884> .
+<http://datos.bne.es/resource/XX450884> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://datos.bne.es/resource/XX450884> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "Nueva York (Nueva York, Estados Unidos)"@es .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasCloseExternalAuthority> <http://www.wikidata.org/entity/Q60> .
+<http://www.wikidata.org/entity/Q60> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://www.wikidata.org/entity/Q60> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "New York City" .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasCloseExternalAuthority> <http://id.worldcat.org/fast/1204333> .
+<http://id.worldcat.org/fast/1204333> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.worldcat.org/fast/1204333> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "New York (State)--New York" .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasDemonym> <http://id.loc.gov/authorities/demographicTerms/dg2022060029> .
+<http://id.loc.gov/authorities/demographicTerms/dg2022060029> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Authority> .
+<http://id.loc.gov/authorities/demographicTerms/dg2022060029> <http://www.loc.gov/mads/rdf/v1#authoritativeLabel> "New Yorkers (New York City)"@en .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/authorities/names/collection_NamesAuthorizedHeadings> .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection> <http://id.loc.gov/authorities/names/collection_LCNAF> .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasExactExternalAuthority> <http://viaf.org/viaf/sourceID/LC%7Cn++79007751#skos:Concept> .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#identifiesRWO> <http://id.loc.gov/rwo/agents/n79007751> .
+<http://id.loc.gov/rwo/agents/n79007751> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#RWO> .
+<http://id.loc.gov/rwo/agents/n79007751> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/standards/mads/rdf/v1#Geographic> .
+<http://id.loc.gov/rwo/agents/n79007751> <http://www.w3.org/2000/01/rdf-schema#label> "New York (N.Y.)" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://www.loc.gov/mads/rdf/v1#isIdentifiedByAuthority> <http://id.loc.gov/authorities/names/n79007751> .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/subjectOf> <http://id.loc.gov/resources/works/11509536> .
+<http://id.loc.gov/resources/works/11509536> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/11509536> <http://id.loc.gov/ontologies/bflc/aap> "[Crowds--ruins--New York]" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/subjectOf> <http://id.loc.gov/resources/works/11509588> .
+<http://id.loc.gov/resources/works/11509588> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/11509588> <http://id.loc.gov/ontologies/bflc/aap> "[Fire prevention parade]" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/subjectOf> <http://id.loc.gov/resources/works/11633385> .
+<http://id.loc.gov/resources/works/11633385> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/11633385> <http://id.loc.gov/ontologies/bflc/aap> "[Newsclips from various newsreels]. [No. 12]" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/subjectOf> <http://id.loc.gov/resources/works/1020732> .
+<http://id.loc.gov/resources/works/1020732> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/1020732> <http://id.loc.gov/ontologies/bflc/aap> "Adams, Barbara Johnston New York City" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/subjectOf> <http://id.loc.gov/resources/works/1089700> .
+<http://id.loc.gov/resources/works/1089700> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/1089700> <http://id.loc.gov/ontologies/bflc/aap> "Capital of the American century" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/subjectOf> <http://id.loc.gov/resources/works/12353102> .
+<http://id.loc.gov/resources/works/12353102> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/12353102> <http://id.loc.gov/ontologies/bflc/aap> "Christmas in New York" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/subjectOf> <http://id.loc.gov/resources/works/10093895> .
+<http://id.loc.gov/resources/works/10093895> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/10093895> <http://id.loc.gov/ontologies/bflc/aap> "De Forest, Emily (Johnston) 1851-1942 John Johnston of New York, merchant" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/subjectOf> <http://id.loc.gov/resources/works/11251799> .
+<http://id.loc.gov/resources/works/11251799> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/11251799> <http://id.loc.gov/ontologies/bflc/aap> "Directory of community services" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/contributorTo> <http://id.loc.gov/resources/works/1303812> .
+<http://id.loc.gov/resources/works/1303812> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/1303812> <http://id.loc.gov/ontologies/bflc/aap> "Dreyfuss, David. A guide to government activities in New York City's housing markets" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/subjectOf> <http://id.loc.gov/resources/works/13683707> .
+<http://id.loc.gov/resources/works/13683707> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/13683707> <http://id.loc.gov/ontologies/bflc/aap> "Dugan, Joanne, 1961- ABC NYC" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/subjectOf> <http://id.loc.gov/resources/works/11510476> .
+<http://id.loc.gov/resources/works/11510476> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/11510476> <http://id.loc.gov/ontologies/bflc/aap> "General Goethals" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/subjectOf> <http://id.loc.gov/resources/works/10531069> .
+<http://id.loc.gov/resources/works/10531069> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/10531069> <http://id.loc.gov/ontologies/bflc/aap> "Hall, Edward Hagaman, 1858-1936 A volume commemorating the creation of the second city of the world" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/subjectOf> <http://id.loc.gov/resources/works/12595964> .
+<http://id.loc.gov/resources/works/12595964> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/12595964> <http://id.loc.gov/ontologies/bflc/aap> "Harrap, Neil Rambling round New York City" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/subjectOf> <http://id.loc.gov/resources/works/11898623> .
+<http://id.loc.gov/resources/works/11898623> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/11898623> <http://id.loc.gov/ontologies/bflc/aap> "Hatt, Christine. New York" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/subjectOf> <http://id.loc.gov/resources/works/11139738> .
+<http://id.loc.gov/resources/works/11139738> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/11139738> <http://id.loc.gov/ontologies/bflc/aap> "Health news" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/subjectOf> <http://id.loc.gov/resources/works/12104290> .
+<http://id.loc.gov/resources/works/12104290> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/12104290> <http://id.loc.gov/ontologies/bflc/aap> "Heckscher, August, 1913-1997 August Heckscher papers" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/subjectOf> <http://id.loc.gov/resources/works/11513977> .
+<http://id.loc.gov/resources/works/11513977> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/11513977> <http://id.loc.gov/ontologies/bflc/aap> "Jackson, William Henry, 1843-1942 New York City views" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/subjectOf> <http://id.loc.gov/resources/works/13065554> .
+<http://id.loc.gov/resources/works/13065554> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/13065554> <http://id.loc.gov/ontologies/bflc/aap> "Jakobsen, Kathy My New York" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/contributorTo> <http://id.loc.gov/resources/works/1275643> .
+<http://id.loc.gov/resources/works/1275643> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/1275643> <http://id.loc.gov/ontologies/bflc/aap> "Jennings, John B. Final evaluation of the Manhattan Criminal Court's master calendar project" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/contributorTo> <http://id.loc.gov/resources/works/1236388> .
+<http://id.loc.gov/resources/works/1236388> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/1236388> <http://id.loc.gov/ontologies/bflc/aap> "Jennings, John B. The flow of arrested adult defendants through the Manhattan Criminal Court in 1968 and 1969" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/subjectOf> <http://id.loc.gov/resources/works/13719806> .
+<http://id.loc.gov/resources/works/13719806> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/13719806> <http://id.loc.gov/ontologies/bflc/aap> "Joel, Billy New York state of mind" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/subjectOf> <http://id.loc.gov/resources/works/11510931> .
+<http://id.loc.gov/resources/works/11510931> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/11510931> <http://id.loc.gov/ontologies/bflc/aap> "Johnston, Frances Benjamin, 1864-1952 Cathedral of St. John the Divine, New York, N.Y" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/subjectOf> <http://id.loc.gov/resources/works/11510929> .
+<http://id.loc.gov/resources/works/11510929> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/11510929> <http://id.loc.gov/ontologies/bflc/aap> "Johnston, Frances Benjamin, 1864-1952 Century Company and McClure Magazine offices, New York, New York" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/subjectOf> <http://id.loc.gov/resources/works/11513458> .
+<http://id.loc.gov/resources/works/11513458> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/11513458> <http://id.loc.gov/ontologies/bflc/aap> "Johnston, Frances Benjamin, 1864-1952 New York and New Jersey architecture and sites" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/subjectOf> <http://id.loc.gov/resources/works/11510901> .
+<http://id.loc.gov/resources/works/11510901> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/11510901> <http://id.loc.gov/ontologies/bflc/aap> "Johnston, Frances Benjamin, 1864-1952 Washington Inauguration Centennial Celebration, New York, N.Y" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/subjectOf> <http://id.loc.gov/resources/works/10114875> .
+<http://id.loc.gov/resources/works/10114875> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/10114875> <http://id.loc.gov/ontologies/bflc/aap> "Journal city" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/subjectOf> <http://id.loc.gov/resources/works/1274454> .
+<http://id.loc.gov/resources/works/1274454> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/1274454> <http://id.loc.gov/ontologies/bflc/aap> "Klein, Alexander, 1918- The Empire City" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/subjectOf> <http://id.loc.gov/resources/works/13738378> .
+<http://id.loc.gov/resources/works/13738378> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/13738378> <http://id.loc.gov/ontologies/bflc/aap> "Latus, Jan, 1960- Stąd widać najlepiej" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/subjectOf> <http://id.loc.gov/resources/works/12449049> .
+<http://id.loc.gov/resources/works/12449049> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/12449049> <http://id.loc.gov/ontologies/bflc/aap> "Lennon, Brian, 1971- City" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/subjectOf> <http://id.loc.gov/resources/works/1004181> .
+<http://id.loc.gov/resources/works/1004181> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/1004181> <http://id.loc.gov/ontologies/bflc/aap> "LeVert, Suzanne New York" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/subjectOf> <http://id.loc.gov/resources/works/10196046> .
+<http://id.loc.gov/resources/works/10196046> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/10196046> <http://id.loc.gov/ontologies/bflc/aap> "Liebling, A. J. (Abbott Joseph), 1904-1963 The telephone booth Indian" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/subjectOf> <http://id.loc.gov/resources/works/10171260> .
+<http://id.loc.gov/resources/works/10171260> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/10171260> <http://id.loc.gov/ontologies/bflc/aap> "Markey, Morris, 1899- Manhattan reporter" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/subjectOf> <http://id.loc.gov/resources/works/10273185> .
+<http://id.loc.gov/resources/works/10273185> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/10273185> <http://id.loc.gov/ontologies/bflc/aap> "McCullough, Esther Morgan As I pass, O Manhattan" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/subjectOf> <http://id.loc.gov/resources/works/11140213> .
+<http://id.loc.gov/resources/works/11140213> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/11140213> <http://id.loc.gov/ontologies/bflc/aap> "Monthly vital statistics review" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/subjectOf> <http://id.loc.gov/resources/works/11540395> .
+<http://id.loc.gov/resources/works/11540395> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/11540395> <http://id.loc.gov/ontologies/bflc/aap> "N. Currier (Firm) City of New York" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/contributorTo> <http://id.loc.gov/resources/works/10065544> .
+<http://id.loc.gov/resources/works/10065544> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/10065544> <http://id.loc.gov/ontologies/bflc/aap> "New York (City) A copy of the poll list" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/contributorTo> <http://id.loc.gov/resources/works/10113038> .
+<http://id.loc.gov/resources/works/10113038> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/10113038> <http://id.loc.gov/ontologies/bflc/aap> "New York (City) Amendments of 1915 to Ash's annotated Greater New York charter" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/contributorTo> <http://id.loc.gov/resources/works/10121646> .
+<http://id.loc.gov/resources/works/10121646> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/10121646> <http://id.loc.gov/ontologies/bflc/aap> "New York (City) Amendments of 1918 to Ash's annotated Greater New York charter" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/contributorTo> <http://id.loc.gov/resources/works/10142341> .
+<http://id.loc.gov/resources/works/10142341> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/10142341> <http://id.loc.gov/ontologies/bflc/aap> "New York (City) Amendments of 1926 to Ash's annotated Greater New York charter" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/contributorTo> <http://id.loc.gov/resources/works/10094698> .
+<http://id.loc.gov/resources/works/10094698> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/10094698> <http://id.loc.gov/ontologies/bflc/aap> "New York (City) An act to unite into one municipality under the corporate name of the City of New York" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/contributorTo> <http://id.loc.gov/resources/works/10044695> .
+<http://id.loc.gov/resources/works/10044695> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/10044695> <http://id.loc.gov/ontologies/bflc/aap> "New York (City) An ordinance regulating the installation and maintenance in buildings of plumbing, water supply, gas and other systems of piping" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/contributorTo> <http://id.loc.gov/resources/works/10007171> .
+<http://id.loc.gov/resources/works/10007171> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/10007171> <http://id.loc.gov/ontologies/bflc/aap> "New York (City) Code of ordinances of the city of New York" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/contributorTo> <http://id.loc.gov/resources/works/10139653> .
+<http://id.loc.gov/resources/works/10139653> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/10139653> <http://id.loc.gov/ontologies/bflc/aap> "New York (City) Laws and ordinances" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/contributorTo> <http://id.loc.gov/resources/works/10129546> .
+<http://id.loc.gov/resources/works/10129546> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/10129546> <http://id.loc.gov/ontologies/bflc/aap> "New York (City) New code of ordinances of the city of New York" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/contributorTo> <http://id.loc.gov/resources/works/10014755> .
+<http://id.loc.gov/resources/works/10014755> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/10014755> <http://id.loc.gov/ontologies/bflc/aap> "New York (City) New York City Charter" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/contributorTo> <http://id.loc.gov/resources/works/10118352> .
+<http://id.loc.gov/resources/works/10118352> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/10118352> <http://id.loc.gov/ontologies/bflc/aap> "New York (City) New York city corporation celebration, commemorating the 250th anniversary of the installation of the first mayor and Board of aldermen and the adoption of the official city flag" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/contributorTo> <http://id.loc.gov/resources/works/10099529> .
+<http://id.loc.gov/resources/works/10099529> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/10099529> <http://id.loc.gov/ontologies/bflc/aap> "New York (City) Ordinances of the mayor, aldermen and commonalty of the city of New York" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/contributorTo> <http://id.loc.gov/resources/works/10016104> .
+<http://id.loc.gov/resources/works/10016104> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/10016104> <http://id.loc.gov/ontologies/bflc/aap> "New York (City) Public documents of the city of New York" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/contributorTo> <http://id.loc.gov/resources/works/10998568> .
+<http://id.loc.gov/resources/works/10998568> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/10998568> <http://id.loc.gov/ontologies/bflc/aap> "New York (City) Report on vital statistics" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/contributorTo> <http://id.loc.gov/resources/works/10043927> .
+<http://id.loc.gov/resources/works/10043927> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/10043927> <http://id.loc.gov/ontologies/bflc/aap> "New York (City) Sanitary code of the Board of Health of the Department of Health of the city of New York, 1899" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/contributorTo> <http://id.loc.gov/resources/works/10516536> .
+<http://id.loc.gov/resources/works/10516536> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/10516536> <http://id.loc.gov/ontologies/bflc/aap> "New York (City) The building code of New York City" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/contributorTo> <http://id.loc.gov/resources/works/10100798> .
+<http://id.loc.gov/resources/works/10100798> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/10100798> <http://id.loc.gov/ontologies/bflc/aap> "New York (City) The charter of the city of New York" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/contributorTo> <http://id.loc.gov/resources/works/10145304> .
+<http://id.loc.gov/resources/works/10145304> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/10145304> <http://id.loc.gov/ontologies/bflc/aap> "New York (City) The Code of ordinances of the city of New York" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/contributorTo> <http://id.loc.gov/resources/works/10148465> .
+<http://id.loc.gov/resources/works/10148465> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/10148465> <http://id.loc.gov/ontologies/bflc/aap> "New York (City) The Code of ordinances of the city of New York" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/contributorTo> <http://id.loc.gov/resources/works/10154649> .
+<http://id.loc.gov/resources/works/10154649> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/10154649> <http://id.loc.gov/ontologies/bflc/aap> "New York (City) The Code of ordinances of the city of New York" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/contributorTo> <http://id.loc.gov/resources/works/10176446> .
+<http://id.loc.gov/resources/works/10176446> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/10176446> <http://id.loc.gov/ontologies/bflc/aap> "New York (City) The Code of ordinances of the city of New York" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/contributorTo> <http://id.loc.gov/resources/works/10200952> .
+<http://id.loc.gov/resources/works/10200952> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/10200952> <http://id.loc.gov/ontologies/bflc/aap> "New York (City) The electrical code of the city of New York" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/contributorTo> <http://id.loc.gov/resources/works/1294017> .
+<http://id.loc.gov/resources/works/1294017> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/1294017> <http://id.loc.gov/ontologies/bflc/aap> "New York (City) The electrical code, 1976" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/contributorTo> <http://id.loc.gov/resources/works/10998354> .
+<http://id.loc.gov/resources/works/10998354> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/10998354> <http://id.loc.gov/ontologies/bflc/aap> "New York (City) The New York City Charter adopted by referendum November 3, 1936, and the Administrative code of the city of New York, chapter 929 of the Laws of 1937, as amended to November 1, 1942, annotated" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/contributorTo> <http://id.loc.gov/resources/works/10998514> .
+<http://id.loc.gov/resources/works/10998514> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/10998514> <http://id.loc.gov/ontologies/bflc/aap> "New York (City) The sanitary code of the city of New York" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/contributorTo> <http://id.loc.gov/resources/works/10000269> .
+<http://id.loc.gov/resources/works/10000269> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/10000269> <http://id.loc.gov/ontologies/bflc/aap> "New York (N.Y.) Address of the Committee to promote the passage of a metropolitan health bill. New-York, December, 1865" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/contributorTo> <http://id.loc.gov/resources/works/13428920> .
+<http://id.loc.gov/resources/works/13428920> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/13428920> <http://id.loc.gov/ontologies/bflc/aap> "New York (N.Y.) Adopted budget, geographic report for capital budget" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/contributorTo> <http://id.loc.gov/resources/works/11168464> .
+<http://id.loc.gov/resources/works/11168464> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/11168464> <http://id.loc.gov/ontologies/bflc/aap> "New York (N.Y.) Capital budget" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/contributorTo> <http://id.loc.gov/resources/works/13875230> .
+<http://id.loc.gov/resources/works/13875230> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/13875230> <http://id.loc.gov/ontologies/bflc/aap> "New York (N.Y.) City of New York, state budget initiatives" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/contributorTo> <http://id.loc.gov/resources/works/13719501> .
+<http://id.loc.gov/resources/works/13719501> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/13719501> <http://id.loc.gov/ontologies/bflc/aap> "New York (N.Y.) Contract budget" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/contributorTo> <http://id.loc.gov/resources/works/13591990> .
+<http://id.loc.gov/resources/works/13591990> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/13591990> <http://id.loc.gov/ontologies/bflc/aap> "New York (N.Y.) Departmental estimates" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/contributorTo> <http://id.loc.gov/resources/works/11206871> .
+<http://id.loc.gov/resources/works/11206871> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/11206871> <http://id.loc.gov/ontologies/bflc/aap> "New York (N.Y.) Executive capital budget" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/contributorTo> <http://id.loc.gov/resources/works/11181713> .
+<http://id.loc.gov/resources/works/11181713> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/11181713> <http://id.loc.gov/ontologies/bflc/aap> "New York (N.Y.) Expense budget - City of New York" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/contributorTo> <http://id.loc.gov/resources/works/11851039> .
+<http://id.loc.gov/resources/works/11851039> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/11851039> <http://id.loc.gov/ontologies/bflc/aap> "New York (N.Y.) Financial plan statements for New York City" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/contributorTo> <http://id.loc.gov/resources/works/13429301> .
+<http://id.loc.gov/resources/works/13429301> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/13429301> <http://id.loc.gov/ontologies/bflc/aap> "New York (N.Y.) Geographic reports for the adopted expense budget" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/contributorTo> <http://id.loc.gov/resources/works/13719547> .
+<http://id.loc.gov/resources/works/13719547> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/13719547> <http://id.loc.gov/ontologies/bflc/aap> "New York (N.Y.) Geographic reports. Year-end financial statement and ... current modified expense budget" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/contributorTo> <http://id.loc.gov/resources/works/10111058> .
+<http://id.loc.gov/resources/works/10111058> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/10111058> <http://id.loc.gov/ontologies/bflc/aap> "New York (N.Y.) Laws, statutes, ordinances and constitutions ordained, made, and established by the mayor, aldermen and commonalty of the City of New-York, convened in Common-Council" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/contributorTo> <http://id.loc.gov/resources/works/13629561> .
+<http://id.loc.gov/resources/works/13629561> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/13629561> <http://id.loc.gov/ontologies/bflc/aap> "New York (N.Y.) Manhattan waterfront greenway map" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/contributorTo> <http://id.loc.gov/resources/works/1240577> .
+<http://id.loc.gov/resources/works/1240577> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/1240577> <http://id.loc.gov/ontologies/bflc/aap> "New York (N.Y.) Minutes of the executive boards of the Burgomasters of New Amsterdam" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/contributorTo> <http://id.loc.gov/resources/works/11403265> .
+<http://id.loc.gov/resources/works/11403265> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/11403265> <http://id.loc.gov/ontologies/bflc/aap> "New York (N.Y.) New York City Charter and Administrative Code. Amendments, complete with indices" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/contributorTo> <http://id.loc.gov/resources/works/11181610> .
+<http://id.loc.gov/resources/works/11181610> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/11181610> <http://id.loc.gov/ontologies/bflc/aap> "New York (N.Y.) New York City fire prevention code" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/contributorTo> <http://id.loc.gov/resources/works/11372321> .
+<http://id.loc.gov/resources/works/11372321> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/11372321> <http://id.loc.gov/ontologies/bflc/aap> "New York (N.Y.) New York City legislative annual" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/contributorTo> <http://id.loc.gov/resources/works/12766559> .
+<http://id.loc.gov/resources/works/12766559> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/12766559> <http://id.loc.gov/ontologies/bflc/aap> "New York (N.Y.) Preliminary ten-year capital strategy" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/contributorTo> <http://id.loc.gov/resources/works/11340268> .
+<http://id.loc.gov/resources/works/11340268> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/11340268> <http://id.loc.gov/ontologies/bflc/aap> "New York (N.Y.) Proposed budget for .." .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/contributorTo> <http://id.loc.gov/resources/works/11340269> .
+<http://id.loc.gov/resources/works/11340269> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/11340269> <http://id.loc.gov/ontologies/bflc/aap> "New York (N.Y.) Proposed budgets for the year ... and for the period .." .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/contributorTo> <http://id.loc.gov/resources/works/10065547> .
+<http://id.loc.gov/resources/works/10065547> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/10065547> <http://id.loc.gov/ontologies/bflc/aap> "New York (N.Y.) Records of the city of New Amsterdam, in the New Netherland" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/contributorTo> <http://id.loc.gov/resources/works/12885826> .
+<http://id.loc.gov/resources/works/12885826> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/12885826> <http://id.loc.gov/ontologies/bflc/aap> "New York (N.Y.) Ten-year capital strategy" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/contributorTo> <http://id.loc.gov/resources/works/13527734> .
+<http://id.loc.gov/resources/works/13527734> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/13527734> <http://id.loc.gov/ontologies/bflc/aap> "New York (N.Y.) The ... green book" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/contributorTo> <http://id.loc.gov/resources/works/12895225> .
+<http://id.loc.gov/resources/works/12895225> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/12895225> <http://id.loc.gov/ontologies/bflc/aap> "New York (N.Y.) The City of New York financial plan" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/contributorTo> <http://id.loc.gov/resources/works/11320973> .
+<http://id.loc.gov/resources/works/11320973> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/11320973> <http://id.loc.gov/ontologies/bflc/aap> "New York (N.Y.) The City of New York official directory" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/contributorTo> <http://id.loc.gov/resources/works/11320966> .
+<http://id.loc.gov/resources/works/11320966> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/11320966> <http://id.loc.gov/ontologies/bflc/aap> "New York (N.Y.) The Green book" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/subjectOf> <http://id.loc.gov/resources/works/11199953> .
+<http://id.loc.gov/resources/works/11199953> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/11199953> <http://id.loc.gov/ontologies/bflc/aap> "New York (N.Y.). Department of Health Quarterly bulletin" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/contributorTo> <http://id.loc.gov/resources/works/13144559> .
+<http://id.loc.gov/resources/works/13144559> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/13144559> <http://id.loc.gov/ontologies/bflc/aap> "New York (N.Y.). Review of the mayor's executive budget for .." .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/contributorTo> <http://id.loc.gov/resources/works/10099457> .
+<http://id.loc.gov/resources/works/10099457> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/10099457> <http://id.loc.gov/ontologies/bflc/aap> "New York (State) Acts of the Legislature of the state relative to the city of New York .." .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/subjectOf> <http://id.loc.gov/resources/works/11135472> .
+<http://id.loc.gov/resources/works/11135472> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/11135472> <http://id.loc.gov/ontologies/bflc/aap> "New York (State). Department of State. Manual for the use of the Legislature of the State of New York" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/subjectOf> <http://id.loc.gov/resources/works/1126109> .
+<http://id.loc.gov/resources/works/1126109> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/1126109> <http://id.loc.gov/ontologies/bflc/aap> "O'Connell, Shaun Remarkable, unspeakable New York" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/subjectOf> <http://id.loc.gov/resources/works/11305098> .
+<http://id.loc.gov/resources/works/11305098> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/11305098> <http://id.loc.gov/ontologies/bflc/aap> "Presbyterian Hospital (New York, N.Y.) Alumni directory" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/subjectOf> <http://id.loc.gov/resources/works/12686033> .
+<http://id.loc.gov/resources/works/12686033> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/12686033> <http://id.loc.gov/ontologies/bflc/aap> "Schulman, Arlene Cop on the beat" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/subjectOf> <http://id.loc.gov/resources/works/11509934> .
+<http://id.loc.gov/resources/works/11509934> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/11509934> <http://id.loc.gov/ontologies/bflc/aap> "Spectacular scenes during a New York City fire" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/subjectOf> <http://id.loc.gov/resources/works/13402408> .
+<http://id.loc.gov/resources/works/13402408> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/13402408> <http://id.loc.gov/ontologies/bflc/aap> "Taxi dreams" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/subjectOf> <http://id.loc.gov/resources/works/12344384> .
+<http://id.loc.gov/resources/works/12344384> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/12344384> <http://id.loc.gov/ontologies/bflc/aap> "The urban lifeworld" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/subjectOf> <http://id.loc.gov/resources/works/11371249> .
+<http://id.loc.gov/resources/works/11371249> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/11371249> <http://id.loc.gov/ontologies/bflc/aap> "The World almanac and encyclopedia" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/subjectOf> <http://id.loc.gov/resources/works/11510285> .
+<http://id.loc.gov/resources/works/11510285> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/11510285> <http://id.loc.gov/ontologies/bflc/aap> "TR's return to New York, 1910 [2]" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/subjectOf> <http://id.loc.gov/resources/works/11100291> .
+<http://id.loc.gov/resources/works/11100291> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/11100291> <http://id.loc.gov/ontologies/bflc/aap> "Uptown New York" .
+<http://id.loc.gov/rwo/agents/n79007751> <http://id.loc.gov/ontologies/bflc/subjectOf> <http://id.loc.gov/resources/works/13191953> .
+<http://id.loc.gov/resources/works/13191953> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
+<http://id.loc.gov/resources/works/13191953> <http://id.loc.gov/ontologies/bflc/aap> "Walsh, Frank New York City" .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#identifiesRWO> <https://d-nb.info/gnd/4042011-5> .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#code> "n-us-ny"^^<http://id.loc.gov/datatypes/codes/gac> .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme> <http://id.loc.gov/authorities/names> .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#editorialNote> "[Non-Latin script references not evaluated.]" .
+<http://id.loc.gov/authorities/names/n79007751> <http://id.loc.gov/vocabulary/identifiers/lccn> "n 79007751" .
+<http://id.loc.gov/authorities/names/n79007751> <http://id.loc.gov/vocabulary/identifiers/local> "(OCoLC)oca00241873" .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasSource> _:b1464iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1464iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Source> .
+_:b1464iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#citationStatus> "found" .
+_:b1464iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#citationSource> "Companhias de comércio exterior, 1973:" .
+_:b1464iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#citationNote> "p. 2 of cover (Nova Iorque)" .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasSource> _:b1472iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1472iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Source> .
+_:b1472iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#citationStatus> "found" .
+_:b1472iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#citationSource> "Ben-Gur, N. Nyu-Yorḳ aḥare ḥamesh, c1982:" .
+_:b1472iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#citationNote> "t.p. (Nyu-Yorḳ) verso t.p. (New-York [in rom.])" .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasSource> _:b1480iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1480iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Source> .
+_:b1480iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#citationStatus> "found" .
+_:b1480iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#citationSource> "Méndez, J.E. Lucha contra el balaguerato, 1980:" .
+_:b1480iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#citationNote> "t.p. (Nueva York, N.Y., U.S.A.)" .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasSource> _:b1488iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1488iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Source> .
+_:b1488iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#citationStatus> "found" .
+_:b1488iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#citationSource> "Ḳinder zshurnal, April 1920:" .
+_:b1488iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#citationNote> "t.p. (Nu Yorḳ)" .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasSource> _:b1496iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1496iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Source> .
+_:b1496iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#citationStatus> "found" .
+_:b1496iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#citationSource> "Yi, Y.G. Nyuyok esŏ choguk ŭl saenggak handa, 1985:" .
+_:b1496iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#citationNote> "t.p. (Nyuyok)" .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasSource> _:b1504iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1504iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Source> .
+_:b1504iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#citationStatus> "found" .
+_:b1504iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#citationSource> "Lenin, V. Di ṭeorye un praḳṭiḳ fun der sotsyaler reṿoltsuye [sic], 1921:" .
+_:b1504iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#citationNote> "t.p. (Nuyorḳ)" .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasSource> _:b1512iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1512iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Source> .
+_:b1512iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#citationStatus> "found" .
+_:b1512iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#citationSource> "The WPA guide to New York City, 1982." .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasSource> _:b1518iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1518iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Source> .
+_:b1518iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#citationStatus> "found" .
+_:b1518iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#citationSource> "Niyū Yūrk awwal marrah, 1996." .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasSource> _:b1524iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1524iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Source> .
+_:b1524iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#citationStatus> "found" .
+_:b1524iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#citationSource> "Niu-yüeh Hua pu ti ku ling ching kuai, 1993." .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasSource> _:b1530iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1530iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Source> .
+_:b1530iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#citationStatus> "found" .
+_:b1530iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#citationSource> "Praworządność w Stanach Zjednoczonych, 1959:" .
+_:b1530iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#citationNote> "t.p. (Nowy Jork)" .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasSource> _:b1538iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1538iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Source> .
+_:b1538iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#citationStatus> "found" .
+_:b1538iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#citationSource> "Paupers and criminals, 1847:" .
+_:b1538iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#citationNote> "t.p. (Corporation of the City of New York)" .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasSource> _:b1546iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1546iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Source> .
+_:b1546iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#citationStatus> "found" .
+_:b1546iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#citationSource> "Wikipedia, May 23, 2011" .
+_:b1546iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#citationNote> "(New York City; New York; City of New York) Afrikaans page (New York Stad) Arabic page (نيويورك = Niyū Yūrk) Aragonese page (Nueva York) Guarani page (Táva Nueva York) Azerbaijani page (Nyu-York [in rom.]; Nyu-York Şähäri [in rom.]) Bashkir page (Нью-Йорк = Nʹi︠u︡-Ĭork) Belarusian page (Горад Нью-Ёрк = Horad Nʹi︠u︡-I︠O︡rk (N.Y.); Нью-Ёрк = Nʹi︠u︡-I︠O︡rk) Bulgarian page (Ню Йорк = Ni︠u︡ Ĭork) Catalan page (Nova York) Chuvash page (Çĕнĕ Йорк = Śĕnĕ Ĭork) Cebuano page (Dakbayan sa New York) Welsh page (Dinas Efrog Newydd; Efrog Newydd) Pennsylvania German page (Nei Yarrick Schtadt; Nei Yarrick) Greek page (Νέα Υόρκη = Nea Yorkē) Spanish page (Nueva York; Ciudad de Nueva York) Esperanto page (Novjorko) French page (New York; Nouvelle York) Irish page (Nua-Eabhrac; Cathair Nua-Eabhrac) Manx page (Caayr York Noa; York Noa) Scottish Gaelic page (Eabhraig Nuadh; Baile Eabhraig Nuadh) Kalmyk page (Нью Йорк балhсн = Nʹi︠u︡ Ĭork balḣsn; Шин Йорк = Shin Ĭork) Korean page (뉴욕 = Nyuyok)" .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasSource> _:b1554iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1554iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Source> .
+_:b1554iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#citationStatus> "found" .
+_:b1554iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#citationSource> "Wikipedia, May 23, 2011" .
+_:b1554iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#citationNote> "Ilokano page (Lungsod ng New York) Inupiak page (Tchiaq York Iniqpak) Icelandic page (New York-borg) Italian page (New York; Nuova York) Hebrew page (ניו יורק = Nyu Yorḳ) Kapampangan page (New York Lakanbalen; Lakanabalen ning New York) Cornish page (Evrek Nowydh) Haitian page (Nouyòk) Kurdish page (Bajarê New Yorkê [in rom.]; New Yorkê [in rom.]) Ladino page (Mueva York [in rom.]; Sivdad de Mueva York [in rom.]; סיבֿדאד די מואיבֿה יורק = Sivdad de Muevah Yorḳ) Latin page (Novum Eboracum; Neo-Eboracum; Civitas Novi Eboraci) Latvian page (Ņujorka) Lithuanian page (Niujorkas; Niujorko miestas) Lojban page (niuiork) Macedonian page (Њујорк = Njujork) Malay page (Bandar Raya New York; Bandaraya New York) Mirandese page (Nuoba Iorque) Mongolian page (Нью-Йорк хот = Nʹi︠u︡-Ĭork khot) Nahuatl page (Āltepētl Yancuīc York) Dutch Low Saxon page (Niej-York) Japanese page (ニューヨーク = Nyū Yōku; ニューヨーク市 = Nyū Yōku-shi)" .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasSource> _:b1562iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1562iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Source> .
+_:b1562iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#citationStatus> "found" .
+_:b1562iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#citationSource> "The NYC software/IT industry, 1999." .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasSource> _:b1568iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1568iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Source> .
+_:b1568iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#citationStatus> "found" .
+_:b1568iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#citationSource> "Son House : \"live\" at Gaslight Cafe, N.Y.C., January 3, 1965, p2000." .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasSource> _:b1574iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1574iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Source> .
+_:b1574iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#citationStatus> "found" .
+_:b1574iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#citationSource> "The new Encyclopædia Britannica, 1995:" .
+_:b1574iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#citationNote> "v. 24, p. 914 (New Amsterdam was the capital of New Netherland; on September 8, 1664 New Amsterdam was seized by the English and the name changed to New York; in 1673 English rule was interupted when the Dutch retook the city and renamed it New Orange [no publs. in LC database]; in 1674 the city reverted to the name New York in accordance with the Treaty of Westminster)" .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#hasSource> _:b1582iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1582iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#Source> .
+_:b1582iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#citationStatus> "found" .
+_:b1582iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#citationSource> "Britannica academic, viewed on April 3, 2019:" .
+_:b1582iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.loc.gov/mads/rdf/v1#citationNote> "under New York City (by 1626 a settlement called New Amsterdam was established)" .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#adminMetadata> _:b1590iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1590iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/RecordInfo#RecordInfo> .
+_:b1590iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/RecordInfo#recordChangeDate> "1979-01-25T00:00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+_:b1590iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/RecordInfo#recordStatus> "new"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b1590iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/RecordInfo#recordContentSource> <http://id.loc.gov/vocabulary/organizations/dlc> .
+_:b1590iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/RecordInfo#languageOfCataloging> <http://id.loc.gov/vocabulary/iso639-2/eng> .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.loc.gov/mads/rdf/v1#adminMetadata> _:b1598iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1598iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/RecordInfo#RecordInfo> .
+_:b1598iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/RecordInfo#recordChangeDate> "2023-08-23T03:01:53"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+_:b1598iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/RecordInfo#recordStatus> "revised"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b1598iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/RecordInfo#recordContentSource> <http://id.loc.gov/vocabulary/organizations/caoonl> .
+_:b1598iddOtlocdOtgovauthoritiesnamesn79007751 <http://id.loc.gov/ontologies/RecordInfo#languageOfCataloging> <http://id.loc.gov/vocabulary/iso639-2/eng> .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#prefLabel> "New York (N.Y.)" .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#prefLabel> "Нью Йорк балhсн (N.Y.)"@zxx-Cyrl .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#prefLabel> "סיבֿדאד די מואיבֿה יורק (N.Y.)"@zxx-Hebr .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#prefLabel> "نيويورك (N.Y.)"@zxx-Arab .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#prefLabel> "ニューヨーク市 (N.Y.)"@zxx-Jpan .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#prefLabel> "Νέα Υόρκη (N.Y.)"@zxx-Grek .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#prefLabel> "뉴욕 (N.Y.)"@zxx-Hang .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b1621iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1621iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b1621iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "New York (City)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b1626iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1626iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b1626iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "Ni︠u︡ Ĭork (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b1631iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1631iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b1631iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "Novi Jork (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b1636iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1636iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b1636iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "Nova Iorque (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b1641iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1641iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b1641iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "Nyu-Yorḳ (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b1646iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1646iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b1646iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "Nueva York (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b1651iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1651iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b1651iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "Nu Yorḳ (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b1656iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1656iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b1656iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "Nyuyok (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b1661iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1661iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b1661iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "Nuyorḳ (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b1666iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1666iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b1666iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "New York City (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b1671iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1671iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b1671iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "Niyū Yūrk (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b1676iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1676iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b1676iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "Niyūyūrk (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b1681iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1681iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b1681iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "Niu-yüeh (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b1686iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1686iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b1686iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "Nowy Jork (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b1691iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1691iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b1691iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "Corporation of the City of New York (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b1696iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1696iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b1696iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "City of New York (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b1701iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1701iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b1701iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "New York Stad (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b1706iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1706iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b1706iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "نيويورك (N.Y.)"@zxx-Arab .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b1711iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1711iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b1711iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "Táva Nueva York (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b1716iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1716iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b1716iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "Nyu-York Şähäri (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b1721iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1721iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b1721iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "Нью-Йорк (N.Y.)"@zxx-Cyrl .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b1726iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1726iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b1726iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "Горад Нью-Ёрк (N.Y.)"@zxx-Cyrl .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b1731iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1731iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b1731iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "Horad Nʹi︠u︡-I︠O︡rk (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b1736iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1736iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b1736iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "Нью-Ёрк (N.Y.)"@zxx-Cyrl .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b1741iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1741iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b1741iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "Ню Йорк (N.Y.)"@zxx-Cyrl .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b1746iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1746iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b1746iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "Nova York (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b1751iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1751iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b1751iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "Çĕнĕ Йорк (N.Y.)"@zxx-Cyrl .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b1756iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1756iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b1756iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "Śĕnĕ Ĭork (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b1761iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1761iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b1761iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "Dakbayan sa New York (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b1766iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1766iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b1766iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "Dinas Efrog Newydd (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b1771iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1771iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b1771iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "Efrog Newydd (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b1776iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1776iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b1776iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "Nei Yarrick Schtadt (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b1781iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1781iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b1781iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "Nei Yarrick (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b1786iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1786iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b1786iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "Νέα Υόρκη (N.Y.)"@zxx-Grek .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b1791iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1791iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b1791iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "Nea Yorkē (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b1796iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1796iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b1796iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "Ciudad de Nueva York (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b1801iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1801iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b1801iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "Novjorko (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b1806iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1806iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b1806iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "Nouvelle York (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b1811iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1811iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b1811iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "Nua-Eabhrac (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b1816iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1816iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b1816iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "Cathair Nua-Eabhrac (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b1821iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1821iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b1821iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "Caayr York Noa (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b1826iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1826iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b1826iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "York Noa (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b1831iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1831iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b1831iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "Eabhraig Nuadh (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b1836iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1836iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b1836iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "Baile Eabhraig Nuadh (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b1841iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1841iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b1841iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "Нью Йорк балhсн (N.Y.)"@zxx-Cyrl .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b1846iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1846iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b1846iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "Nʹi︠u︡ Ĭork balḣsn (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b1851iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1851iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b1851iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "Шин Йорк (N.Y.)"@zxx-Cyrl .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b1856iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1856iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b1856iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "Shin Ĭork (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b1861iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1861iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b1861iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "뉴욕 (N.Y.)"@zxx-Hang .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b1866iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1866iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b1866iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "Lungsod ng New York (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b1871iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1871iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b1871iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "Tchiaq York Iniqpak (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b1876iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1876iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b1876iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "Tchiaq York (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b1881iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1881iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b1881iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "New York-borg (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b1886iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1886iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b1886iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "Nuova York (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b1891iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1891iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b1891iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "ניו יורק (N.Y.)"@zxx-Hebr .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b1896iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1896iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b1896iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "New York Lakanbalen (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b1901iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1901iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b1901iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "Lakanabalen ning New York (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b1906iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1906iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b1906iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "Evrek Nowydh (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b1911iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1911iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b1911iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "Nouyòk (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b1916iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1916iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b1916iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "Bajarê New Yorkê (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b1921iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1921iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b1921iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "New Yorkê (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b1926iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1926iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b1926iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "Mueva York (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b1931iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1931iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b1931iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "Sivdad de Mueva York (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b1936iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1936iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b1936iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "סיבֿדאד די מואיבֿה יורק (N.Y.)"@zxx-Hebr .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b1941iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1941iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b1941iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "Sivdad de Muevah Yorḳ (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b1946iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1946iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b1946iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "מואיבֿה יורק (N.Y.)"@zxx-Hebr .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b1951iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1951iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b1951iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "Muevah Yorḳ (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b1956iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1956iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b1956iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "Novum Eboracum (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b1961iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1961iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b1961iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "Neo-Eboracum (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b1966iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1966iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b1966iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "Civitas Novi Eboraci (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b1971iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1971iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b1971iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "Ņujorka (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b1976iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1976iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b1976iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "Niujorkas (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b1981iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1981iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b1981iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "Niujorko miestas (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b1986iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1986iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b1986iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "Niuiork (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b1991iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1991iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b1991iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "Њујорк (N.Y.)"@zxx-Cyrl .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b1996iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b1996iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b1996iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "Njujork (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b2001iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b2001iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b2001iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "Bandar Raya New York (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b2006iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b2006iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b2006iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "Bandaraya New York (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b2011iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b2011iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b2011iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "Nuoba Iorque (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b2016iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b2016iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b2016iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "Нью-Йорк хот (N.Y.)"@zxx-Cyrl .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b2021iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b2021iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b2021iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "Nʹi︠u︡-Ĭork khot (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b2026iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b2026iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b2026iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "Āltepētl Yancuīc York (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b2031iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b2031iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b2031iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "Niej-York (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b2036iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b2036iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b2036iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "ニューヨーク (N.Y.)"@zxx-Jpan .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b2041iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b2041iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b2041iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "Nyū Yōku (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b2046iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b2046iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b2046iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "ニューヨーク市 (N.Y.)"@zxx-Jpan .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b2051iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b2051iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b2051iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "Nyū Yōku-shi (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b2056iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b2056iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b2056iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "NYC (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2008/05/skos-xl#altLabel> _:b2061iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b2061iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2008/05/skos-xl#Label> .
+_:b2061iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/2008/05/skos-xl#literalForm> "N.Y.C. (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2000/01/rdf-schema#related> <http://id.loc.gov/authorities/demographicTerms/dg2022060029> .
+<http://id.loc.gov/authorities/demographicTerms/dg2022060029> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<http://id.loc.gov/authorities/demographicTerms/dg2022060029> <http://www.w3.org/2004/02/skos/core#prefLabel> "New Yorkers (New York City)"@en .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#related> <http://id.loc.gov/authorities/names/n2019017691> .
+<http://id.loc.gov/authorities/names/n2019017691> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<http://id.loc.gov/authorities/names/n2019017691> <http://www.w3.org/2004/02/skos/core#prefLabel> "New Amsterdam (New Netherland)" .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#exactMatch> <http://viaf.org/viaf/sourceID/LC%7Cn++79007751#skos:Concept> .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#closeMatch> <http://datos.bne.es/resource/XX450884> .
+<http://datos.bne.es/resource/XX450884> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<http://datos.bne.es/resource/XX450884> <http://www.w3.org/2004/02/skos/core#prefLabel> "Nueva York (Nueva York, Estados Unidos)"@es .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#closeMatch> <http://www.wikidata.org/entity/Q60> .
+<http://www.wikidata.org/entity/Q60> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<http://www.wikidata.org/entity/Q60> <http://www.w3.org/2004/02/skos/core#prefLabel> "New York City" .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#closeMatch> <http://id.worldcat.org/fast/1204333> .
+<http://id.worldcat.org/fast/1204333> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<http://id.worldcat.org/fast/1204333> <http://www.w3.org/2004/02/skos/core#prefLabel> "New York (State)--New York" .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#editorialNote> "[Non-Latin script references not evaluated.]" .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#notation> "n-us-ny"^^<http://id.loc.gov/datatypes/codes/gac> .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#inScheme> <http://id.loc.gov/authorities/names> .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "New York (City)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "Ni︠u︡ Ĭork (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "Novi Jork (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "Nova Iorque (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "Nyu-Yorḳ (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "Nueva York (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "Nu Yorḳ (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "Nyuyok (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "Nuyorḳ (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "New York City (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "Niyū Yūrk (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "Niyūyūrk (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "Niu-yüeh (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "Nowy Jork (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "Corporation of the City of New York (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "City of New York (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "New York Stad (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "نيويورك (N.Y.)"@zxx-Arab .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "Táva Nueva York (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "Nyu-York Şähäri (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "Нью-Йорк (N.Y.)"@zxx-Cyrl .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "Горад Нью-Ёрк (N.Y.)"@zxx-Cyrl .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "Horad Nʹi︠u︡-I︠O︡rk (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "Нью-Ёрк (N.Y.)"@zxx-Cyrl .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "Ню Йорк (N.Y.)"@zxx-Cyrl .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "Nova York (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "Çĕнĕ Йорк (N.Y.)"@zxx-Cyrl .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "Śĕnĕ Ĭork (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "Dakbayan sa New York (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "Dinas Efrog Newydd (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "Efrog Newydd (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "Nei Yarrick Schtadt (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "Nei Yarrick (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "Νέα Υόρκη (N.Y.)"@zxx-Grek .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "Nea Yorkē (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "Ciudad de Nueva York (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "Novjorko (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "Nouvelle York (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "Nua-Eabhrac (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "Cathair Nua-Eabhrac (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "Caayr York Noa (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "York Noa (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "Eabhraig Nuadh (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "Baile Eabhraig Nuadh (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "Нью Йорк балhсн (N.Y.)"@zxx-Cyrl .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "Nʹi︠u︡ Ĭork balḣsn (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "Шин Йорк (N.Y.)"@zxx-Cyrl .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "Shin Ĭork (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "뉴욕 (N.Y.)"@zxx-Hang .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "Lungsod ng New York (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "Tchiaq York Iniqpak (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "Tchiaq York (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "New York-borg (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "Nuova York (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "ניו יורק (N.Y.)"@zxx-Hebr .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "New York Lakanbalen (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "Lakanabalen ning New York (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "Evrek Nowydh (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "Nouyòk (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "Bajarê New Yorkê (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "New Yorkê (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "Mueva York (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "Sivdad de Mueva York (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "סיבֿדאד די מואיבֿה יורק (N.Y.)"@zxx-Hebr .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "Sivdad de Muevah Yorḳ (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "מואיבֿה יורק (N.Y.)"@zxx-Hebr .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "Muevah Yorḳ (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "Novum Eboracum (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "Neo-Eboracum (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "Civitas Novi Eboraci (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "Ņujorka (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "Niujorkas (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "Niujorko miestas (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "Niuiork (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "Њујорк (N.Y.)"@zxx-Cyrl .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "Njujork (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "Bandar Raya New York (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "Bandaraya New York (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "Nuoba Iorque (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "Нью-Йорк хот (N.Y.)"@zxx-Cyrl .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "Nʹi︠u︡-Ĭork khot (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "Āltepētl Yancuīc York (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "Niej-York (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "ニューヨーク (N.Y.)"@zxx-Jpan .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "Nyū Yōku (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "ニューヨーク市 (N.Y.)"@zxx-Jpan .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "Nyū Yōku-shi (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "NYC (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#altLabel> "N.Y.C. (N.Y.)"@zxx-Latn .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#changeNote> _:b2275iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b2275iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/vocab/changeset/schema#ChangeSet> .
+_:b2275iddOtlocdOtgovauthoritiesnamesn79007751 <http://purl.org/vocab/changeset/schema#subjectOfChange> <http://id.loc.gov/authorities/names/n79007751> .
+_:b2275iddOtlocdOtgovauthoritiesnamesn79007751 <http://purl.org/vocab/changeset/schema#creatorName> <http://id.loc.gov/vocabulary/organizations/dlc> .
+_:b2275iddOtlocdOtgovauthoritiesnamesn79007751 <http://purl.org/vocab/changeset/schema#createdDate> "1979-01-25T00:00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+_:b2275iddOtlocdOtgovauthoritiesnamesn79007751 <http://purl.org/vocab/changeset/schema#changeReason> "new"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://id.loc.gov/authorities/names/n79007751> <http://www.w3.org/2004/02/skos/core#changeNote> _:b2283iddOtlocdOtgovauthoritiesnamesn79007751 .
+_:b2283iddOtlocdOtgovauthoritiesnamesn79007751 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/vocab/changeset/schema#ChangeSet> .
+_:b2283iddOtlocdOtgovauthoritiesnamesn79007751 <http://purl.org/vocab/changeset/schema#subjectOfChange> <http://id.loc.gov/authorities/names/n79007751> .
+_:b2283iddOtlocdOtgovauthoritiesnamesn79007751 <http://purl.org/vocab/changeset/schema#creatorName> <http://id.loc.gov/vocabulary/organizations/caoonl> .
+_:b2283iddOtlocdOtgovauthoritiesnamesn79007751 <http://purl.org/vocab/changeset/schema#createdDate> "2023-08-23T03:01:53"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+_:b2283iddOtlocdOtgovauthoritiesnamesn79007751 <http://purl.org/vocab/changeset/schema#changeReason> "revised"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/spec/indexers/uri_to_string_behavior_spec.rb
+++ b/spec/indexers/uri_to_string_behavior_spec.rb
@@ -35,11 +35,11 @@ RSpec.describe UriToStringBehavior do
       end
 
       context 'from the Library of Congress' do
-        let(:uri) { 'http://id.loc.gov/vocabulary/iso639-2/eng' }
+        let(:uri) { 'http://id.loc.gov/authorities/names/n79007751' }
         let(:rdf_data) { Rails.root.join('spec', 'fixtures', 'rdf_data', 'loc.nt').to_s }
 
         it 'retrieves a value for a given URI' do
-          expect(subject.uri_to_value_for(uri)).to eq 'English'
+          expect(subject.uri_to_value_for(uri)).to eq 'New York (N.Y.)'
         end
       end
 


### PR DESCRIPTION
We see a few LOC rdf records that don't have any language tags specifically for english while other languages to have tags.  This commit will add another fallback and assume the string without a language tag is the English one.

Ref:
- https://github.com/notch8/utk-hyku/issues/696
