### PR TITLE
🧹 Allow thumbnails to be viewed by anyone

### DIFF
--- a/app/assets/stylesheets/themes/dc_show.scss
+++ b/app/assets/stylesheets/themes/dc_show.scss
@@ -167,14 +167,12 @@ body.dc_show {
   .uv-panel {
     padding: 0;
 
-    .thumbnail-container {
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      text-align: center;
-
-      .representative-media {
-        width: auto;
+    .panel-body {
+      .row {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        text-align: center;
       }
     }
   }

--- a/app/controllers/hyrax/downloads_controller_decorator.rb
+++ b/app/controllers/hyrax/downloads_controller_decorator.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
-# OVERRIDE Hyrax 3.5.0 allow downloading directly from S3
+# OVERRIDE Hyrax 3.6.0 allow downloading directly from S3
+#   and allow thumbnails to be accessed by anyone
 
 require 'aws-sdk-s3'
 
@@ -39,6 +40,14 @@ module Hyrax
 
       fname
     end
+
+    private
+
+      def authorize_download!
+        return if params['file'] == 'thumbnail'
+
+        super
+      end
   end
 end
 


### PR DESCRIPTION
This commit will add an override to the `Hyrax::DownloadsController` to check if the incoming request is asking for the thumbnail.  It it is then we will skip authorization.  This way even if the file set is private/institution, then thumbnail is still viewable.

Ref:
- https://github.com/notch8/utk-hyku/issues/647

![image](https://github.com/user-attachments/assets/5e519263-4cba-431d-a8b9-e8959970a5fc)
