### PR TITLE
Remove ldp calls from views

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,7 +21,7 @@ GIT
 
 GIT
   remote: https://github.com/samvera-labs/allinson_flex.git
-  revision: 581b58d57a90440f71d5d4ad8e1a9e4316ea92a3
+  revision: 2516ad1b84ee02b87c34118b729095e2a6e83ee2
   specs:
     allinson_flex (0.1.0)
       json_schemer

--- a/app/controllers/hyrax/downloads_controller_decorator.rb
+++ b/app/controllers/hyrax/downloads_controller_decorator.rb
@@ -2,6 +2,7 @@
 
 # OVERRIDE Hyrax 3.6.0 allow downloading directly from S3
 #   and allow thumbnails to be accessed by anyone
+#   and to override :file_set_parent to use Solr first before going to Fedora
 
 require 'aws-sdk-s3'
 
@@ -47,6 +48,16 @@ module Hyrax
         return if params['file'] == 'thumbnail'
 
         super
+      end
+
+      def file_set_parent(file_set_id)
+        parent =
+          Hyrax::SolrService
+          .query("-has_model_ssim:FileSet AND file_set_ids_ssim:#{params[asset_param_key]}", rows: 1)
+          .first
+        return super if parent.nil?
+
+        ::SolrDocument.new(parent)
       end
   end
 end


### PR DESCRIPTION
## ⬆️ Update AllinsonFlex gem

cd1d74bd8a72e891f2e2a649d0148fdea4f247d8

This commit will update the AllinsonFlex gem to bring in a more
efficient query and remove LDP calls from the views.

Ref:
- https://github.com/samvera-labs/allinson_flex/pull/125
- https://github.com/samvera-labs/allinson_flex/pull/126
- https://github.com/samvera-labs/allinson_flex/pull/127

## 🧹 Add override for :file_set_parent

3c06d155760e1cb90e36571d6d30ab47f49d2357

This commit will override Hyrax to check Solr before going to Fedora.
