### PR TITLE
🐛 Fix File Manager save button

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,7 +75,7 @@ GIT
 
 GIT
   remote: https://github.com/samvera/hyrax.git
-  revision: 3b972faa2a0a0e5688854def09877da8bdb283a8
+  revision: a4890955954a6d5d824a4c8786374f9ff54355e3
   branch: hyrax-3.x+chunked
   specs:
     hyrax (3.6.0)

--- a/app/actors/hyrax/actors/apply_order_actor_decorator.rb
+++ b/app/actors/hyrax/actors/apply_order_actor_decorator.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# OVERRIDE Hyrax v3.6.0 to remove nils from :ordered_member_ids
+# TODO: Why were nils in ordered_member_ids?  I had one locally but after using this to save, it cleared itself up.
+
+module Hyrax
+  module Actors
+    module ApplyOrderActorDecorator
+      def cleanup_ids_to_remove_from_curation_concern(curation_concern, ordered_member_ids)
+        (curation_concern.ordered_member_ids.compact - ordered_member_ids).each do |old_id|
+          # rubocop:disable Rails/DynamicFindBy
+          work = Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: old_id, use_valkyrie: false)
+          # rubocop:enable Rails/DynamicFindBy
+          curation_concern.ordered_members.delete(work)
+          curation_concern.members.delete(work)
+        end
+      end
+    end
+  end
+end
+
+Hyrax::Actors::ApplyOrderActor.prepend(Hyrax::Actors::ApplyOrderActorDecorator)


### PR DESCRIPTION
The file manager save button was still disabled even after changes were made to the files.  This was caused by a selector error because we are running jQuery 3.  That change was made in Hyrax.  The other change was to add a decorator for the `Hyrax::Actors::ApplyOrderActor` to compact and nil objects in the ordered_member_ids.  Why and how it got in there in the first place?  I haven't been able to solve that part.  But, after saving it with this override, it seemed to fix the issue and I no longer see the nil in ordered_member_ids.

Ref:
- https://github.com/notch8/utk-hyku/issues/580
- https://github.com/samvera/hyrax/commit/a4890955954a6d5d824a4c8786374f9ff54355e3

Wait for it...
![file manager](https://github.com/user-attachments/assets/4786f485-edac-491f-a063-d544b950a686)
