### PR TITLE
🎁 Add a proxy for VTT transcript file

### DIFF
--- a/app/controllers/supplementing_content_controller.rb
+++ b/app/controllers/supplementing_content_controller.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class SupplementingContentController < ApplicationController
+  def show
+    file_set_document = SolrDocument.find(params[:id])
+    transcript = file_set_document['transcript_tsimv']&.first
+    return render plain: 'No content found', status: :not_found if transcript.blank?
+
+    send_data transcript, type: 'text/vtt', disposition: 'inline'
+  end
+end

--- a/app/indexers/hyrax/file_set_indexer_decorator.rb
+++ b/app/indexers/hyrax/file_set_indexer_decorator.rb
@@ -9,6 +9,9 @@ module Hyrax
         # digest of the original file if we are using an external file due to s3 direct upload
         solr_doc['digest_ssim'] = "urn:sha1:#{object.s3_only}" if object.s3_only.present?
         solr_doc['rdf_type_ssim'] = object.parent_works.first.rdf_type if attachment?
+        if solr_doc['rdf_type_ssim']&.first == 'http://pcdm.org/use#Transcript'
+          solr_doc['transcript_tsimv'] = object.files.first.content
+        end
         solr_doc['all_text_tesimv'] = solr_doc['all_text_tsimv'] if solr_doc['all_text_tsimv'].present?
       end
     end

--- a/app/presenters/hyrax/iiif_manifest_presenter_decorator.rb
+++ b/app/presenters/hyrax/iiif_manifest_presenter_decorator.rb
@@ -106,12 +106,18 @@ module Hyrax
 
         def create_supplementing_content(attachment)
           hash = get_file_set_ids_and_languages(attachment)
-          captions_url = get_captions_url(hash[:file_set_id])
-          IIIFManifest::V3::SupplementingContent.new(captions_url,
-                                                     type: 'Text',
-                                                     format: 'text/vtt',
-                                                     label: hash[:title],
-                                                     language: hash[:language] || 'en')
+
+          captions_url = Rails.application.routes.url_helpers.supplementing_content_url(
+            id: hash[:file_set_id], protocol: 'https'
+          )
+
+          IIIFManifest::V3::SupplementingContent.new(
+            captions_url,
+            type: 'Text',
+            format: 'text/vtt',
+            label: hash[:title],
+            language: hash[:language] || 'en'
+          )
         end
 
         def get_file_set_ids_and_languages(doc)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -136,4 +136,8 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
   post "/dashboard/collections/:id/delete_uploaded_thumbnail",
     to: "hyrax/dashboard/collections#delete_uploaded_thumbnail",
     as: :delete_uploaded_thumbnail
+
+  # Use proxy URL for S3 content to avoid CORS issues
+  # see #create_supplementing_content in app/presenters/hyrax/iiif_manifest_presenter_decorator.rb
+  get 'supplementing_content/:id(.:format)', to: 'supplementing_content#show', as: 'supplementing_content'
 end

--- a/spec/requests/supplementing_content_controller_spec.rb
+++ b/spec/requests/supplementing_content_controller_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SupplementingContentController, type: :controller do
+  let(:file_set_id) { 'some_file_set_id' }
+  let(:file_set_doc) { SolrDocument.new(id: file_set_id, transcript_tsimv: [transcript]) }
+  let(:transcript) { "WEBVTT\n\n00:00:01.000 --> 00:00:05.000\nThis is a test VTT" }
+
+  before do
+    allow(SolrDocument).to receive(:find).with(file_set_id).and_return(file_set_doc)
+  end
+
+  describe 'GET #show' do
+    context 'when the file set has a transcript' do
+      it 'returns a success response' do
+        get :show, params: { id: 'some_file_set_id' }
+        expect(response).to be_successful
+        expect(response.content_type).to eq('text/vtt')
+        expect(response.body).to eq(transcript)
+        expect(response.headers['Content-Disposition']).to include('inline')
+      end
+    end
+
+    context 'when there is no digest' do
+      let(:transcript) { [] }
+
+      it "returns not found status" do
+        get :show, params: { id: 'some_file_set_id' }
+        expect(response).to have_http_status(:not_found)
+        expect(response.body).to eq('No content found')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Since we're in an S3 backed Fedora environment, CloverIIIF makes a call to S3 to get the VTT content, however it gets blocked because of CORS issues.  This commit adds a proxy to the Rails app to get around that.

Ref:
- https://github.com/notch8/utk-hyku/issues/442
