### PR TITLE
🐛 Guard all .mappings calls

### DIFF
--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -101,6 +101,8 @@ class SolrDocument
       fields = []
 
       blacklight_field_properties.each do |prop|
+        next if prop.nil?
+
         mapping = YAML.safe_load(prop.mappings.gsub(/=>/, ':'))['blacklight']
         fields << mapping if mapping.present?
       end
@@ -134,13 +136,15 @@ class SolrDocument
 
         return [] if @profile.blank?
 
-        @profile.properties.select { |property| property.mappings&.include?('blacklight') }
+        @profile.properties.select { |property| property&.mappings&.include?('blacklight') }
       end
 
       def fields_by_blacklight_mapping(mapping_value)
         fields = []
 
         blacklight_field_properties.each do |prop|
+          next if prop.nil?
+
           fields << prop.name.to_s if YAML.safe_load(prop.mappings.gsub(/=>/, ':'))['blacklight'] == mapping_value
         end
         fields.uniq


### PR DESCRIPTION
This commit will add a lonely operator to all .mappings calls.  We are seeing this happen in a worker and it is unclear why, but this should at least make it no error out.
