### PR TITLE
🐛 Use prescribed label on work show page

### DIFF
--- a/app/views/themes/dc_show/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/themes/dc_show/hyrax/base/_attribute_rows.html.erb
@@ -4,12 +4,12 @@
   <%# @todo internationalisation %>
   <% next if Rails.configuration.hidden_properties.include?(prop_key) %>
   <% next if prop_value[:admin_only] && !presenter.current_ability.current_user.admin? %>
-  <% next if prop_value[:grouped] unless [:rights_statement, :license].include? prop_key %>
+  <% next if prop_value[:grouped] unless [:rights_statement].include? prop_key %>
   <%# Only rights_statement and license have special render_as options %>
   <% value = if [:rights_statement, :license].include? prop_key %>
-    <% presenter.attribute_to_html(prop_key, render_as: prop_key, html_dl: true) %>
+    <% presenter.attribute_to_html(prop_key, render_as: prop_key, html_dl: true, label: prop_value[:label]) %>
   <% else %>
-    <% presenter.attribute_to_html(prop_key, label: prop_value[:label], html_dl: true) %>
+    <% presenter.attribute_to_html(prop_key, label: prop_value[:label], html_dl: true, label: prop_value[:label]) %>
   <% end %>
   <% if value.present? && (prop_key != :abstract) %>
     <div class='metadata-group'>


### PR DESCRIPTION
This commit will allow the work show page to use the prescribed label from the AllinsonFlex profile to be displayed on the work show page.

Ref:
- https://github.com/notch8/utk-hyku/issues/637

```yml
  rights_statement:
    display_label:
      default: Rights
```
Before:
<img width="1177" alt="image" src="https://github.com/user-attachments/assets/19ea9785-1fad-4ef2-bafd-833009c17248" />

After:
<img width="1099" alt="image" src="https://github.com/user-attachments/assets/ebeb8cfd-f40f-49be-8ad1-aadba48eced2" />
