### PR TITLE
I680 fix oai feed

### DIFF
--- a/app/models/concerns/mods_solr_document.rb
+++ b/app/models/concerns/mods_solr_document.rb
@@ -150,7 +150,7 @@ module ModsSolrDocument
         xml.url({ usage: 'primary', access: "object in context" }, object_url)
         if self[:thumbnail_path_ss].present?
           thumbnail_url = url.gsub('?file=thumbnail', '')
-          xml.url(access: 'preview', "xlink:href" => thumbnail_url)
+          xml.url({ access: 'preview' }, thumbnail_url)
         end
       end
     end

--- a/app/models/concerns/mods_solr_document.rb
+++ b/app/models/concerns/mods_solr_document.rb
@@ -99,8 +99,8 @@ module ModsSolrDocument
     # originInfo
     def load_origin(xml)
       xml.originInfo do
-        date_created_d&.each { |value| xml.dateCreated value.to_s }
-        date_issued_d&.each { |value| xml.dateIssued value.to_s }
+        Array.wrap(date_created_d).each { |value| xml.dateCreated value.to_s if value.present? }
+        Array.wrap(date_issued_d).each { |value| xml.dateIssued value.to_s if value.present? }
       end
     end
 

--- a/lib/blacklight_oai_provider/solr_document_wrapper_decorator.rb
+++ b/lib/blacklight_oai_provider/solr_document_wrapper_decorator.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# OVERRIDE Blacklight OAI Provider v6.1.1 to filter out unwanted work types
+
+module BlacklightOaiProvider
+  module SolrDocumentWrapperDecorator
+    private
+
+      def conditions(_options)
+        query = super
+
+        # Add our filter to exclude what we want to exclude from catalog search
+        # according to IIIF Print's configuration
+        IiifPrint.config.excluded_model_name_solr_field_values.each do |model|
+          query.append_filter_query("-has_model_ssim:#{model}")
+        end
+
+        query
+      end
+  end
+end
+
+BlacklightOaiProvider::SolrDocumentWrapper.prepend(BlacklightOaiProvider::SolrDocumentWrapperDecorator)


### PR DESCRIPTION
## 🧹 Filter out unwanted work types from OAI feed

841a4af991d98d6ead3c2360e6af363fbabfed2f

This commit will add an override for the Blacklight OAI Provider gem to
add a fq for unwanted work types.  We're keying off of the
IiifPrint::SearchBuilder to keep things consistent.  At the moment, we
don't want Attachment work types to show int he Catalog searches nor in
the OAI feed.

Ref:
- https://github.com/notch8/utk-hyku/issues/680

## 🐛 Array wrap `date_created_d` and `date_issued_d`

d6ac6330ef9bafe5ac279a84a72a23dcfdf633c3

This commit will add an array wrap for `date_created_d` and
`date_issued_d` because it is coming in as a single value.

## 🧹 Remove `xlink:href` attribute for thumbnail

8569d523b6fd99e9cd6a8aa4f4b95c7ea5681910

This commit will move the thumbnail url from the `xlink:href` attribute
become the actual value of the tag.

<img width="1559" alt="image" src="https://github.com/user-attachments/assets/3810cb61-f72c-459f-8726-92d72590ff18" />

## 🎁 Add links to item and resource to oai_dc feed

4ff44334c8d9d3898c42290bd59baf002976d33c

This commit will add the links to the item and also to the thumbnail to
the oai_dc feed.

Ref:
- https://github.com/notch8/utk-hyku/issues/680

<img width="992" alt="image" src="https://github.com/user-attachments/assets/3fe873c5-b836-46ef-8766-22c9dfe982f9" />


