### PR TITLE
🐛 Add more room for transcripts

### DIFF
--- a/app/assets/stylesheets/viewer.scss
+++ b/app/assets/stylesheets/viewer.scss
@@ -2,6 +2,23 @@
   height: 500px;
 }
 
+.hyrax-videos-show, .hyrax-audios-show {
+  @media (max-width: 991px) {
+    .viewer-wrapper {
+      height: 750px;
+    }
+  }
+
+  @media (max-width: 767px) {
+    .viewer-wrapper {
+      iframe {
+        position: relative;
+        width: 90vw;
+      }
+    }
+  }
+}
+
 .viewer {
   height: 100%;
   padding: 10px;


### PR DESCRIPTION
This commit will add css to Audio and Video work types (which use the CloverIIIF viewer) to make the height taller so there is room to view it when transcripts are opened.

Ref:
- https://github.com/notch8/utk-hyku/issues/726

https://github.com/user-attachments/assets/295495cf-b641-44cf-b43a-855c166b9e8f

