### PR TITLE
🐛 Rework CloverIIIF css

### DIFF
--- a/app/assets/stylesheets/viewer.scss
+++ b/app/assets/stylesheets/viewer.scss
@@ -2,19 +2,17 @@
   height: 500px;
 }
 
-.hyrax-videos-show, .hyrax-audios-show {
-  @media (max-width: 991px) {
-    .viewer-wrapper {
-      height: 750px;
-    }
+@media (max-width: 991px) {
+  .clover-iiif-viewer {
+    height: 750px;
   }
+}
 
-  @media (max-width: 767px) {
-    .viewer-wrapper {
-      iframe {
-        position: relative;
-        width: 90vw;
-      }
+@media (max-width: 767px) {
+  .viewer-wrapper, .clover-iiif-viewer {
+    iframe {
+      position: relative;
+      width: 90vw;
     }
   }
 }

--- a/app/views/hyrax/base/iiif_viewers/_clover_iiif.erb
+++ b/app/views/hyrax/base/iiif_viewers/_clover_iiif.erb
@@ -1,4 +1,4 @@
-<div class="viewer-wrapper">
+<div class="viewer-wrapper clover-iiif-viewer">
   <iframe
     id="clover-iiif-iframe"
     src="<%= clover_iiif_base_url %>?manifest=<%= main_app.polymorphic_url [main_app, :manifest, presenter], { locale: nil } %>&config=<%= clover_iiif_config_url %>"


### PR DESCRIPTION
This commit will take a different approach since the first approach assumed that only Audio and Video works would render the CloverIIIF viewer which is not the case.

Ref:
- https://github.com/notch8/utk-hyku/issues/726
