### PR TITLE
🐛 Add handling for non-UTF-8 encoded characters

### DIFF
--- a/app/indexers/hyrax/file_set_indexer_decorator.rb
+++ b/app/indexers/hyrax/file_set_indexer_decorator.rb
@@ -10,7 +10,11 @@ module Hyrax
         solr_doc['digest_ssim'] = "urn:sha1:#{object.s3_only}" if object.s3_only.present?
         solr_doc['rdf_type_ssim'] = object.parent_works.first.rdf_type if attachment?
         if solr_doc['rdf_type_ssim']&.first == 'http://pcdm.org/use#Transcript'
-          solr_doc['transcript_tsimv'] = object.files.first.content
+          content = object.files.first&.content&.encode('UTF-8', 'binary',
+                                                        invalid: :replace,
+                                                        undef: :replace,
+                                                        replace: '')
+          solr_doc['transcript_tsimv'] = content if content
         end
         solr_doc['all_text_tesimv'] = solr_doc['all_text_tsimv'] if solr_doc['all_text_tsimv'].present?
       end


### PR DESCRIPTION
Found a `x97` on a file, we need to handle that.