### PR TITLE
🐛 Overwrite Bulkrax::ScheduleRelationshipsJob

### DIFF
--- a/app/jobs/bulkrax/schedule_relationships_job_decorator.rb
+++ b/app/jobs/bulkrax/schedule_relationships_job_decorator.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# OVERRIDE Bulkrax v9.0.2 to alter the query so we kick off the relationship jobs at the correct time
+
+module Bulkrax
+  module ScheduleRelationshipsJobDecorator
+    def perform(importer_id:)
+      importer = Importer.find(importer_id)
+
+      processed_entries =
+        Bulkrax::Status
+        .where(statusable_id: importer.entries.pluck(:id))
+        .where(runnable_id: importer.last_run.id)
+        .where(status_message: ['Complete', 'Failed', 'Skipped'])
+        .pluck(:statusable_id).uniq
+      pending_entries = importer.entries.where.not(id: processed_entries)
+      pending_num = pending_entries.count
+
+      return reschedule(importer_id) unless pending_num.zero?
+
+      importer.last_run.parents.each do |parent_id|
+        Bulkrax.relationship_job_class.constantize.perform_later(parent_identifier: parent_id,
+                                                                 importer_run_id: importer.last_run.id)
+      end
+    end
+  end
+end
+
+Bulkrax::ScheduleRelationshipsJob.prepend(Bulkrax::ScheduleRelationshipsJobDecorator)

--- a/app/jobs/bulkrax/schedule_relationships_job_decorator.rb
+++ b/app/jobs/bulkrax/schedule_relationships_job_decorator.rb
@@ -11,7 +11,7 @@ module Bulkrax
         Bulkrax::Status
         .where(statusable_id: importer.entries.pluck(:id))
         .where(runnable_id: importer.last_run.id)
-        .where(status_message: ['Complete', 'Failed', 'Skipped'])
+        .where.not(status_message: 'Pending')
         .pluck(:statusable_id).uniq
       pending_entries = importer.entries.where.not(id: processed_entries)
       pending_num = pending_entries.count


### PR DESCRIPTION
This commit will use a different query to get the pending_num value.  We were seeing that the query in current Bulkrax is prematurely going to zero. Testing it out in UTK and refining it before considering contributing back to Bulkrax.

Ref:
- https://github.com/notch8/utk-hyku/issues/737
