### PR TITLE
🐛 Fix collection sorting

### DIFF
--- a/app/search_builders/hyrax/collection_search_builder_decorator.rb
+++ b/app/search_builders/hyrax/collection_search_builder_decorator.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# OVERRIDE Hyrax v3.6.0 to check the blacklight_params for the sort value
+
+module Hyrax
+  module CollectionSearchBuilderDecorator
+    def add_sorting_to_solr(solr_parameters)
+      return if solr_parameters[:q]
+      solr_parameters[:sort] ||= blacklight_params[:sort] || super
+    end
+  end
+end
+
+Hyrax::CollectionSearchBuilder.prepend(Hyrax::CollectionSearchBuilderDecorator)


### PR DESCRIPTION
This commit will add an override to the `Hyrax::CollectionSearchBuilder` so we can check the `blacklight_params[:sort]`, which is where the sort param is coming from.  This way the param doesn't default to `title_si asc` which does nothing for us.

Ref:
- https://github.com/notch8/utk-hyku/issues/740

![utk-collection-sort](https://github.com/user-attachments/assets/890ef55f-17e2-493e-bee9-a18124685442)
