### PR TITLE
🐛 Fix Collection facet not showing

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -83,6 +83,7 @@ class CatalogController < ApplicationController
 
     # solr fields that will be treated as facets by the blacklight application
     #   The ordering of the field names is the order of the display
+    config.add_facet_field 'member_of_collections_ssim', label: "Collections", limit: 5
     config.add_facet_field 'date_created_d_sim', label: "Date Created",
                                                  range: {
                                                    num_segments: 6,
@@ -104,7 +105,6 @@ class CatalogController < ApplicationController
     config.add_facet_field 'form_local_sim', label: "Form", limit: 5
     config.add_facet_field 'resource_type_sim', label: "Resource Type", limit: 5
     config.add_facet_field 'rights_sim', label: "Rights", limit: 5
-    config.add_facet_field 'member_of_collections_sim', label: "Collections", limit: 5
     config.add_facet_field 'temporal_sim', label: "Temporal Coverage", limit: 5
 
     # Have BL send all facet field names to Solr, which has been the default

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe CatalogController, type: :controller do
       expect(facet_fields['form_local_sim'].limit).to eq 5
       expect(facet_fields['intermediate_provider_sim'].limit).to eq 5
       expect(facet_fields['resource_type_sim'].limit).to eq 5
-      expect(facet_fields['member_of_collections_sim'].limit).to eq 5
+      expect(facet_fields['member_of_collections_ssim'].limit).to eq 5
       expect(facet_fields['spatial_sim'].limit).to eq 5
     end
 
@@ -56,7 +56,7 @@ RSpec.describe CatalogController, type: :controller do
       expect(facet_fields['license_sim'].label).to eq 'License'
       expect(facet_fields['resource_type_sim'].label).to eq 'Resource Type'
       expect(facet_fields['rights_statement_sim'].label).to eq 'Rights Statement'
-      expect(facet_fields['member_of_collections_sim'].label).to eq 'Collections'
+      expect(facet_fields['member_of_collections_ssim'].label).to eq 'Collections'
       expect(facet_fields['spatial_sim'].label).to eq 'Location'
     end
 


### PR DESCRIPTION
I'm not sure how it was ever working but the solr field was incorrect for the collection facet.  That has been fixed and the Collection facet was moved to the top.

![image](https://github.com/user-attachments/assets/6cc235ef-7f85-485b-9d95-2b8c3886511c)
