### PR TITLE
🐛 Fix Bulkrax exports

### DIFF
--- a/app/models/bulkrax/exporter_decorator.rb
+++ b/app/models/bulkrax/exporter_decorator.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# OVERRIDE Bulkrax v9.0.2 because field.mapping only included bulkrax.rb parser_mappings because all other
+#   metdata fields are handled in AllinsonFlex.
+module Bulkrax
+  module ExporterDecorator
+    def mapping
+      @mapping ||= flex_metadata_mappings.merge(super) || {}
+    end
+
+    private
+
+      def flex_metadata_mappings
+        ActiveSupport::HashWithIndifferentAccess.new(
+          export_properties.map do |m|
+            Bulkrax.default_field_mapping.call(m)
+          end.inject(:merge)
+        )
+      end
+  end
+end
+
+Bulkrax::Exporter.prepend(Bulkrax::ExporterDecorator)

--- a/app/models/concerns/bulkrax/export_behavior_decorator.rb
+++ b/app/models/concerns/bulkrax/export_behavior_decorator.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+# OVERRIDE Bulkrax v9.0.2 to account for UTK filesets not having extensions
+
+module Bulkrax
+  module ExportBehaviorDecorator
+    def filename(file_set)
+      return if file_set.original_file.blank?
+      if file_set.original_file.respond_to?(:original_filename) # valkyrie
+        fn = file_set.original_file.original_filename
+        mime = ::Marcel::MimeType.for(file_set.original_file.file.io)
+      else # original non valkyrie version
+        fn = file_set.original_file.file_name.first
+        mime = ::Marcel::MimeType.for(declared_type: file_set.original_file.mime_type)
+      end
+      ext_mime = ::Marcel::MimeType.for(name: fn)
+      # OVERRIDE begin
+      if File.extname(fn).blank?
+        filename = "#{file_set.id}_#{fn}" + Rack::Mime::MIME_TYPES.invert[mime]
+      elsif fn.include?(file_set.id) || importerexporter.metadata_only?
+        # OVERRIDE end
+        filename = "#{fn}.#{mime.to_sym}"
+        filename = fn if mime.to_s == ext_mime.to_s
+      else
+        filename = "#{file_set.id}_#{fn}.#{mime.to_sym}"
+        filename = "#{file_set.id}_#{fn}" if mime.to_s == ext_mime.to_s
+      end
+      # Remove extention truncate and reattach
+      ext = File.extname(filename)
+      "#{File.basename(filename, ext)[0...(220 - ext.length)]}#{ext}"
+    end
+  end
+end
+
+Bulkrax::ExportBehavior.prepend(Bulkrax::ExportBehaviorDecorator)

--- a/app/parsers/bulkrax/parser_export_record_set_decorator.rb
+++ b/app/parsers/bulkrax/parser_export_record_set_decorator.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# OVERRIDE Bulkrax v9.0.2 to account for child works since UTK has the Attachment layer
+
+module Bulkrax
+  module ParserExportRecordSetDecorator
+    module BaseDecorator
+      private
+
+        def works
+          @works ||= begin
+            @works = Bulkrax.object_factory.query(works_query, **works_query_kwargs)
+            child_works = []
+            @works.each do |parent_work|
+              member_ids = parent_work['member_ids_ssim']
+              next unless member_ids
+
+              member_ids.each do |id|
+                child_work = Hyrax::SolrService.query("id:#{id}", row: 1, fl: "id,member_ids_ssim")
+                child_works += child_work
+              end
+            end
+
+            @works += child_works
+          end
+        end
+    end
+  end
+end
+
+Bulkrax::ParserExportRecordSet::Base.prepend(Bulkrax::ParserExportRecordSetDecorator::BaseDecorator)


### PR DESCRIPTION
This commit will add three Bulkrax overrides.

1. `Bulkrax::ParserExportRecordSetDecorator::BaseDecorator`
  - UTK has an Attachment work that holds the file sets, this override handles the child works.
2. `Bulkrax::ExporterDecorator`
  - Because we are using AllinsonFlex, we don't have much in the Bulkrax parser_mappings.  This will allow all the metadata to be added to the csv.
3. `Bulkrax::ExportBehaviorDecorator`
  - UTK filenames are imported without file extensions.  We had to use this override to account for that otherwise we end up with no filenames at all and files will override each other in the files dir.

Ref:
- https://github.com/notch8/utk-hyku/issues/18
