### PR TITLE
🎁 Adjust collection searching

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -69,7 +69,7 @@ class CatalogController < ApplicationController
     config.default_solr_params = {
       qt: "search",
       rows: 10,
-      qf: "title_tesim description_tesim creator_tesim keyword_tesim all_text_timv all_text_tesimv"
+      qf: "title_tesim description_tesim abstract_tesim creator_tesim keyword_tesim all_text_timv all_text_tesimv"
     }
 
     # Specify which field to use in the tag cloud on the homepage.


### PR DESCRIPTION
UTK has an Attachment work type that serves as a proxy for the file set. When Attachments are added to works they are not added to the collection that the work is added to.  This causes an inconsistency between the catalog search and the collection search.  Attachments are found in the catalog search but return their parent works and in a collection search Attachments are not found at all since they are not directly apart of the the collection.

This commit will alter the collection search builder so that the Attachment that is a member of a work that is the member of the collection will be returned.  However, we don't want to just return the Attachment object, we return it's parent as a result.

Also, the `abstract` field is what we're actually using instead of `description`, so we are adding `abstract_tesim` to do the default solr params qf.

Lastly, `member_of_collection` was being added again to the `default_processor_chain` which is not need since it's being added to in Hyrax.  We remove the duplication here so it doesn't get called twice.

## `MP4` is on the title of the Attachment
<img width="1251" alt="image" src="https://github.com/user-attachments/assets/d3dd8647-36c4-44d5-b64b-0b14d4832966" />

## Searching `MP4` returns the parent work from the collection search
<img width="1270" alt="image" src="https://github.com/user-attachments/assets/78b3d13c-a4cb-4945-b96b-ac3a76c55e70" />

