### PR TITLE
🎁 Add more metadata and search results

### DIFF
--- a/app/assets/stylesheets/hyku.scss
+++ b/app/assets/stylesheets/hyku.scss
@@ -489,3 +489,8 @@ body.public-facing {
 body.dashboard #content-wrapper table[aria-label="Resource Types"].table.table-striped.sr-only.text-left {
   display: none;
 }
+
+// Collection show page search results
+.matching-child-works {
+  padding-bottom: 2rem;
+}

--- a/app/controllers/hyrax/collections_controller_decorator.rb
+++ b/app/controllers/hyrax/collections_controller_decorator.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# OVERRIDE Hyrax v3.6.0 so we can set the @child_works_mapper so we can get the search results
+
+module Hyrax
+  module CollectionsControllerDecorator
+    private
+
+      def member_works
+        @response = collection_member_service.available_member_works
+        @member_docs = @response.documents
+        @members_count = @response.total
+        @child_works_mapper = child_works_mapper
+      end
+      alias load_member_works member_works
+
+      def child_works_mapper
+        @member_docs.each_with_object({}) do |parent_doc, hash|
+          next if parent_doc['matching_children'].blank?
+
+          hash[parent_doc.id] = parent_doc['matching_children']['docs'].map { |mc| ::SolrDocument.new(mc) }
+        end
+      end
+  end
+end
+
+Hyrax::CollectionsController.prepend(Hyrax::CollectionsControllerDecorator)

--- a/app/renderers/hyrax/renderers/attribute_renderer_decorator.rb
+++ b/app/renderers/hyrax/renderers/attribute_renderer_decorator.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# OVERRIDE: Hyrax v3.6.0 to add truncation support for attribute values in the attribute renderer
+
+module Hyrax
+  module Renderers
+    module AttributeRendererDecorator
+      private
+
+        def li_value(value)
+          if options[:truncate] && value.to_s.length > options[:truncate]
+            value = ERB::Util.h(value.to_s.truncate(
+                                  options[:truncate],
+                                  separator: options[:separator] || ' ',
+                                  omission: options[:omission] || '...'
+            ))
+          end
+
+          super(value)
+        end
+    end
+  end
+end
+
+Hyrax::Renderers::AttributeRenderer.prepend(Hyrax::Renderers::AttributeRendererDecorator)

--- a/app/search_builders/hyrax/collection_member_search_builder_decorator.rb
+++ b/app/search_builders/hyrax/collection_member_search_builder_decorator.rb
@@ -6,6 +6,7 @@
 module Hyrax
   module CollectionMemberSearchBuilderDecorator
     include IiifPrint::AllinsonFlexFields
+
     def member_of_collection(solr_parameters)
       super
 
@@ -18,6 +19,19 @@ module Hyrax
       solr_parameters[:q] = '{!lucene}' \
                             '_query_:"{!dismax v=$user_query}" ' \
                             '_query_:"{!join from=id to=file_set_ids_ssim}{!dismax v=$user_query}"'
+    end
+
+    def matching_children(solr_parameters)
+      user_query = solr_parameters[:user_query]
+      return if user_query.blank?
+
+      current_fl = solr_parameters[:fl] || '*'
+      solr_parameters[:fl] = "#{current_fl},matching_children:[subquery]"
+
+      solr_parameters['matching_children.q'] = "{!terms f=id v=$row.file_set_ids_ssim} AND #{user_query}"
+      solr_parameters['matching_children.fl'] = '*'
+      solr_parameters['matching_children.qf'] = solr_parameters[:qf]
+      solr_parameters['matching_children.rows'] = 10
     end
 
     def apply_viewer_access_permissions(solr_parameters)
@@ -34,4 +48,4 @@ end
 
 Hyrax::CollectionMemberSearchBuilder.prepend(Hyrax::CollectionMemberSearchBuilderDecorator)
 Hyrax::CollectionMemberSearchBuilder
-  .default_processor_chain += %i[apply_viewer_access_permissions include_allinson_flex_fields]
+  .default_processor_chain += %i[apply_viewer_access_permissions matching_children include_allinson_flex_fields]

--- a/app/views/hyrax/collections/_matching_child_works.html.erb
+++ b/app/views/hyrax/collections/_matching_child_works.html.erb
@@ -1,0 +1,6 @@
+<%= content_tag :div, class: 'matching-child-works' do %>
+  <em>Search results found in:</em>
+  <%= documents.each_with_object([]) do |document, arr| %>
+    <% arr << (link_to document.title_or_label, [main_app, document]) %>
+  <% end.to_sentence.html_safe %>
+<% end %>

--- a/app/views/hyrax/collections/_show_document_list_row.html.erb
+++ b/app/views/hyrax/collections/_show_document_list_row.html.erb
@@ -1,0 +1,33 @@
+<%#
+  OVERRIDE Hyrax v3.6.0 to render work metadata and search results
+%>
+
+<% id = document.id %>
+<tr id="document_<%= id %>">
+  <td>&nbsp;
+    <% if current_user and document.depositor != current_user.user_key %>
+      <i class="glyphicon glyphicon-share-alt" />
+    <% end %>
+  </td>
+  <td>
+    <div class="media">
+      <%= link_to [main_app, document], "class" => "media-left", "aria-hidden" => "true" do %>
+        <%= render_thumbnail_tag document, { class: "hidden-xs file_listing_thumbnail", alt: "#{document.title_or_label} #{t('hyrax.homepage.admin_sets.thumbnail')}" }, { suppress_link: true } %>
+      <% end %>
+      <div class="media-body">
+        <p class="media-heading">
+          <strong><%= link_to document.title_or_label, [main_app, document], id: "src_copy_link#{id}", class: "#{'document-title' if document.title_or_label == document.label}" %></strong>
+        </p>
+        <%= render_other_collection_links(document, @presenter.id) %>
+        <%# OVERRIDE begin %>
+        <%= render 'matching_child_works', documents: @child_works_mapper[document.id] if @child_works_mapper[document.id].present? %>
+        <%= render 'work_metadata', presenter: Hyrax::WorkShowPresenter.new(document, current_ability) %>
+        <%# OVERRIDE end %>
+      </div>
+    </div>
+  </td>
+  <td class="text-center"><%= document.date_uploaded %> </td>
+  <td class="text-center">
+    <%= render_visibility_link(document) %>
+  </td>
+</tr>

--- a/app/views/hyrax/collections/_work_metadata.html.erb
+++ b/app/views/hyrax/collections/_work_metadata.html.erb
@@ -1,0 +1,2 @@
+<%= presenter.attribute_to_html(:abstract, html_dl: true, truncate: 250) %>
+<%= presenter.attribute_to_html(:date_issued, html_dl: true) || presenter.attribute_to_html(:date_created, html_dl: true) %>


### PR DESCRIPTION
Previously, we were only given the thumbnail and the title of the work on the collection's show page.  Now we have the abstract and date issued/date created.  In addition, if we are doing a search and get a hit, there will be a search result indicating with child work (usually the Attachment) had the search term.

Ref:
- https://github.com/notch8/utk-hyku/issues/750

<img width="1237" alt="image" src="https://github.com/user-attachments/assets/fd7a6b40-c6cc-4a78-8821-50e4c8ef9373" />
