### PR TITLE
⚙️ Remove keyword from facets

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -95,7 +95,6 @@ class CatalogController < ApplicationController
     config.add_facet_field 'creator_sim', limit: 5
     config.add_facet_field 'contributor_sim', label: "Contributor", limit: 5
     config.add_facet_field 'intermediate_provider_sim', label: "Intermediate Provider", limit: 5
-    config.add_facet_field 'keyword_sim', limit: 5
     config.add_facet_field 'subject_sim', limit: 5
     config.add_facet_field 'language_sim', limit: 5
     config.add_facet_field 'spatial_sim', label: "Location", limit: 5

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -35,7 +35,6 @@ RSpec.describe CatalogController, type: :controller do
       expect(facet_fields['human_readable_type_sim'].limit).to eq 5
       expect(facet_fields['creator_sim'].limit).to eq 5
       expect(facet_fields['contributor_sim'].limit).to eq 5
-      expect(facet_fields['keyword_sim'].limit).to eq 5
       expect(facet_fields['subject_sim'].limit).to eq 5
       expect(facet_fields['language_sim'].limit).to eq 5
       expect(facet_fields['based_near_label_sim'].limit).to eq 5


### PR DESCRIPTION
The `keyword` facet should not be displayed since it is all aggregated into `subject`.
