### PR TITLE
🐛 Favor ActiveFedora::Base.where

### DIFF
--- a/app/factories/bulkrax/object_factory_decorator.rb
+++ b/app/factories/bulkrax/object_factory_decorator.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# OVERRIDE Bulkrax v9.0.2 to use .where instead of .find because UTK uses colons in their
+#   bulkrax identifiers which causes issues when using .find
+
+module Bulkrax
+  module ObjectFactoryDecorator
+    def find(id)
+      object = ActiveFedora::Base.where(bulkrax_identifier_tesim: id).first
+      return object if object.present?
+
+      super
+    end
+  end
+end
+
+Bulkrax::ObjectFactory.singleton_class.send(:prepend, Bulkrax::ObjectFactoryDecorator)


### PR DESCRIPTION
This commit will add an override to Bulkrax to use ActiveFedora::Base.where instead of ActiveFedora::Base.find because we're seeing problems when searching for an "id" with a colon. The id is actually the bulkrax identifier during one of the runs.

ISSUE: 
- https://github.com/notch8/utk-hyku/issues/767
