### PR TITLE
🧹 Convert URI for collection resource types

### DIFF
--- a/app/indexers/collection_indexer.rb
+++ b/app/indexers/collection_indexer.rb
@@ -14,6 +14,7 @@ class CollectionIndexer < Hyrax::CollectionIndexer
       solr_doc["subject_sim"] = solr_doc["subject_tesim"] = converter.convert_uri_to_value(['subject'])
       solr_doc["contributor_sim"] = solr_doc["contributor_tesim"] = converter.convert_uri_to_value(['contributor'])
       solr_doc["language_sim"] = solr_doc["language_tesim"] = converter.convert_uri_to_value(['language'])
+      solr_doc["resource_type_sim"] = solr_doc["resource_type_tesim"] = converter.convert_uri_to_value(['resource_type']) # rubocop:disable Metrics/LineLength
       solr_doc["bulkrax_identifier_sim"] = object.bulkrax_identifier
       solr_doc["account_cname_tesim"] = Site.instance&.account&.cname
       solr_doc[CatalogController.title_field] = Array(object.title).first


### PR DESCRIPTION
# ⚠️ REINDEX OF COLLECTIONS REQUIRED ⚠️

This commit will add resource types as a property to be converted from URIs to strings for a Collection.

Ref:
- https://github.com/notch8/utk-hyku/issues/756

### Before
<img width="1234" alt="image" src="https://github.com/user-attachments/assets/750b51e7-a3dd-408e-8520-f5569911bf3d" />

### After
<img width="1244" alt="image" src="https://github.com/user-attachments/assets/d3f29df1-2196-4b89-a15b-b9b7db216edd" />