### PR TITLE
Fix show view not displaying work

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ gem 'blacklight_oai_provider', '~> 6.1', '>= 6.1.1'
 gem 'blacklight_range_limit', '~> 7.0'
 gem 'bolognese', '>= 1.9.10'
 gem 'bootstrap-datepicker-rails'
-gem 'bulkrax', github: 'samvera/bulkrax', branch: 'main'
+gem 'bulkrax', github: 'samvera/bulkrax', ref: '03d7e8bf87e52777321ae2d572bd5d221ca40f5c'
 gem 'byebug', group: %i[development test]
 gem 'capybara', group: %i[test]
 gem 'capybara-screenshot', '~> 1.0', group: %i[test]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,7 +54,7 @@ GIT
 GIT
   remote: https://github.com/samvera/bulkrax.git
   revision: 03d7e8bf87e52777321ae2d572bd5d221ca40f5c
-  branch: main
+  ref: 03d7e8bf87e52777321ae2d572bd5d221ca40f5c
   specs:
     bulkrax (9.0.2)
       bagit (~> 0.6.0)
@@ -775,7 +775,7 @@ GEM
       rdf-vocab (~> 3.0)
     legato (0.7.0)
       multi_json
-    libxml-ruby (5.0.3)
+    libxml-ruby (5.0.4)
     link_header (0.0.8)
     linkeddata (3.1.6)
       equivalent-xml (~> 0.6)

--- a/app/views/themes/dc_show/hyrax/base/_representative_media.html.erb
+++ b/app/views/themes/dc_show/hyrax/base/_representative_media.html.erb
@@ -2,8 +2,7 @@
   OVERRIDE Hyrax v3.6.0 to check if the work has all attachments that are set to institution.
   If so then the UV should not show and instead display the thumbnail.
 %>
-
-<% if presenter.representative_id.present? && presenter.representative_presenter.present? %>
+<% if presenter.representative_id.present? && presenter.representative_presenter.present? && presenter.representative_presenter.file_set_ids.present? %>
   <% if defined?(viewer) && viewer && (!attachments_with_institution_visibility?(presenter) || current_user) %>
     <%= iiif_viewer_display presenter %>
   <% else %>


### PR DESCRIPTION
# Story

Refs #764

In UTK's application structure, a work's attachment object is saved as the representative ID. When a work's representative image's attachment has the file sets removed, the attachment remains listed as the representative. This then breaks the show page because the code looks for what type of file the representative is when there are no files.

Additionally, Bulkrax is being locked to its current hash, as subsequent changes introduced changes to the CreateRelationshipsJob which break the overrides. We do not want to unintentionally update Bulkrax, so leaving it on `main` branch is problematic. 

# Expected Behavior Before Changes

Removing the filesets off of a work and leaving the attachment breaks the work's show page.

# Expected Behavior After Changes

Removing the filesets off of a work and leaving the attachment does not break the show page.

# Notes

There were multiple potential ways to handle this, but given the desire for attachments to always have files, and the unknown desired behavior when deleting filesets, we took the simplest approach to simply verify that filesets exist before trying to display a representative. 

Other possible solutions were considered:
- remove the representative ID on the work when removing a fileset from the work's resentative attachment.
- create a callback to remove the attachment itself when removing the fileset. This clears the representative id from the work and prevents the broken view.

Both of these options were significantly more work, and we were unsure which of these might be the desired behavior. Additionally, either of these would have also required a migration to clean up broken records which already exist. Given the intended structure of all attachments having files, we assume that cleanup is already planned, and the additional work would be unnecessary.