### PR TITLE
Schedule relationships

### DIFF
--- a/app/parsers/bulkrax/application_parser_decorator.rb
+++ b/app/parsers/bulkrax/application_parser_decorator.rb
@@ -19,9 +19,14 @@ module Bulkrax
           e.status_info('Pending', importer.current_run)
           if remove_and_rerun
             delay = calculate_type_delay(type)
-            "Bulkrax::DeleteAndImport#{type.camelize}Job".constantize.set(wait: delay).send(perform_method, e, current_run)
+            "Bulkrax::DeleteAndImport#{type.camelize}Job"
+              .constantize
+              .set(wait: delay)
+              .send(perform_method, e, current_run)
           else
-            "Bulkrax::Import#{type.camelize}Job".constantize.send(perform_method, e.id, current_run.id)
+            "Bulkrax::Import#{type.camelize}Job"
+              .constantize
+              .send(perform_method, e.id, current_run.id)
           end
           increment_counters(index)
           index += 1

--- a/app/parsers/bulkrax/application_parser_decorator.rb
+++ b/app/parsers/bulkrax/application_parser_decorator.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# OVERRIDE Bulkrax v9.0.2 03d7e8bf87e52777321ae2d572bd5d221ca40f5c
+#          to schedule relationships job when editing and resubmitting a parser as we do with a new parser.
+#  TODO: Remove this override when Bulkrax is updated to a version that includes this fix.
+
+module Bulkrax
+  module ApplicationParserDecorator
+    def rebuild_entries(types_array = nil)
+      index = 0
+      (types_array || %w[collection work file_set relationship]).each do |type|
+        # works are not gurneteed to have Work in the type
+        if type.eql?('relationship')
+          ScheduleRelationshipsJob.set(wait: 5.minutes).perform_later(importer_id: importerexporter.id)
+          next
+        end
+        importer.entries.where(rebuild_entry_query(type, parser_fields['entry_statuses'])).find_each do |e|
+          seen[e.identifier] = true
+          e.status_info('Pending', importer.current_run)
+          if remove_and_rerun
+            delay = calculate_type_delay(type)
+            "Bulkrax::DeleteAndImport#{type.camelize}Job".constantize.set(wait: delay).send(perform_method, e, current_run)
+          else
+            "Bulkrax::Import#{type.camelize}Job".constantize.send(perform_method, e.id, current_run.id)
+          end
+          increment_counters(index)
+          index += 1
+        end
+      end
+    end
+  end
+end
+
+Bulkrax::ApplicationParser.prepend(Bulkrax::ApplicationParserDecorator)


### PR DESCRIPTION
# Story

Refs #742

This change adds a decorator for the Bulkrax ApplicationParser to enqueue a ScheduleRelationshipsJob when an importer is edited and rerun. This allows for the import process to appropriately schedule relationships during a rerun as it does during the initial import.

This change was added to Bulkrax (https://github.com/samvera/bulkrax/pull/1043), but there are changes to the CreateRelationshipsJob subsequent to the version used in this repo that are not compatible with the overrides in this repo. Updating Bulkrax to the latest version would require refactoring the CreateRelationshipsJob overrides, which are potentially risky and therefore not feasible at this time.

# Expected Behavior Before Changes

When editing an importer and selecting "current entries" along with any of the checkbox options, the relationships are ignored.

# Expected Behavior After Changes

When editing an importer and selecting "current entries" along with any of the checkbox options, ScheduleRelationshipsJob gets enqueued and relationships are added.

# Screenshots / Video

<details>
<summary></summary>

</details>

# Notes