### PR TITLE
Add report of incomplete filesets

### DIFF
--- a/app/services/incomplete_works_service.rb
+++ b/app/services/incomplete_works_service.rb
@@ -66,7 +66,8 @@ class IncompleteWorksService
       # Skip this item if parent query returned no results
       next if parent_result.empty?
       parent_model = parent_result.first&.dig('has_model_ssim')&.first
-      parent_id = hash['is_page_of_ssim'].first
+      parent_id = hash['is_page_of_ssim']&.first
+      next if parent_id.nil?
 
       "https://#{Site.account.cname}/concern/parent/#{parent_id}/attachments/#{hash['id']};" \
       "#{parent_model};" \
@@ -117,8 +118,10 @@ class IncompleteWorksService
       # Add a header row if needed
       csv << headers
 
+      break if data.empty?
       # Process each string in the array
       data.each do |str|
+        next unless str.is_a?(String)
         parts = str.split(';')
         csv << parts
       end

--- a/app/services/incomplete_works_service.rb
+++ b/app/services/incomplete_works_service.rb
@@ -58,10 +58,14 @@ class IncompleteWorksService
     return [] if results.empty?
 
     results.map do |hash|
-      parent_model = Hyrax::SolrService.query(
+      parent_result = Hyrax::SolrService.query(
         "id:#{hash['is_page_of_ssim'].first}",
         rows: 1
-      ).first['has_model_ssim'].first
+      )
+
+      # Skip this item if parent query returned no results
+      next if parent_result.empty?
+      parent_model = parent_result.first&.dig('has_model_ssim')&.first
       parent_id = hash['is_page_of_ssim'].first
 
       "https://#{Site.account.cname}/concern/parent/#{parent_id}/attachments/#{hash['id']};" \

--- a/app/services/incomplete_works_service.rb
+++ b/app/services/incomplete_works_service.rb
@@ -3,8 +3,8 @@
 require 'csv'
 
 # IncompleteWorksService is responsible for generating reports on incomplete works
-# in the digital collections. It identifies attachments without filesets
-# and works without attachments, generating CSV files for each report.
+# in the digital collections. It identifies attachments without filesets, works
+# without attachments, and filesets without files, generating CSV files for each report.
 #
 # Usage:
 #   IncompleteWorksService.run_reports
@@ -16,25 +16,26 @@ class IncompleteWorksService
   #
   # @return [void]
   #
-  # Generates two CSV files:
+  # Generates up to 3 CSV files:
   # - attachments_without_filesets.csv: Lists attachments without associated filesets.
   # - works_without_attachments.csv: Lists works that do not have any attachments.
+  # - filesets_without_files.csv: Lists filesets that do not have any files.
   def self.run_reports(reports: %i[no_files no_attachments no_filesets], rows: 100_000)
     # Create CSV for attachments without filesets
     if reports.include?(:no_filesets)
       data = no_filesets(rows: rows)
       create_csv(data: data,
-                  output_file: 'attachments_without_filesets.csv',
-                  headers: ["Attachment URL", "Work Type", "Bulkrax Identifier", "Parent URL"])
+                 output_file: 'attachments_without_filesets.csv',
+                 headers: ["Attachment URL", "Work Type", "Bulkrax Identifier", "Parent URL"])
       Rails.logger.info "Created attachments_without_filesets.csv in public/uploads"
     end
 
-     # Create CSV for filesets without files
+    # Create CSV for filesets without files
     if reports.include?(:no_files)
       data = no_files(rows: rows)
       create_csv(data: data,
-                  output_file: 'filesets_without_files.csv',
-                  headers: ["File Set URL", "FileSet Title", "Bulkrax Identifier", "Import URL"])
+                 output_file: 'filesets_without_files.csv',
+                 headers: ["File Set URL", "FileSet Title", "Bulkrax Identifier", "Import URL"])
       Rails.logger.info "Created filesets_without_files.csv in public/uploads"
     end
 

--- a/app/services/incomplete_works_service.rb
+++ b/app/services/incomplete_works_service.rb
@@ -64,10 +64,10 @@ class IncompleteWorksService
       ).first['has_model_ssim'].first
       parent_id = hash['is_page_of_ssim'].first
 
-      "https://digitalcollections.lib.utk.edu/concern/parent/#{parent_id}/attachments/#{hash['id']};" \
+      "https://#{Site.account.cname}/concern/parent/#{parent_id}/attachments/#{hash['id']};" \
       "#{parent_model};" \
       "#{hash['bulkrax_identifier_tesim']&.first};" \
-      "https://digitalcollections.lib.utk.edu/concern/#{parent_model.underscore.pluralize}/#{parent_id}"
+      "https://#{Site.account.cname}/concern/#{parent_model.underscore.pluralize}/#{parent_id}"
     end
   end
 
@@ -82,7 +82,7 @@ class IncompleteWorksService
     end
 
     results.flatten.map do |hash|
-      "https://digitalcollections.lib.utk.edu/concern/#{hash['has_model_ssim'].first.downcase.pluralize}/" \
+      "https://#{Site.account.cname}/concern/#{hash['has_model_ssim'].first.downcase.pluralize}/" \
       "#{hash['id']};" \
       "#{hash['has_model_ssim'].first};" \
       "#{hash['bulkrax_identifier_tesim']&.first}"
@@ -98,7 +98,7 @@ class IncompleteWorksService
     return [] if results.empty?
 
     results.map do |hash|
-      "https://digitalcollections.lib.utk.edu/concern/file_sets/#{hash['id']};" \
+      "https://#{Site.account.cname}/concern/file_sets/#{hash['id']};" \
       "#{hash['title_tesim'].first};" \
       "#{hash['bulkrax_identifier_tesim']&.first};" \
       "#{hash['import_url_ssim']&.first}"

--- a/lib/tasks/incomplete_works.rake
+++ b/lib/tasks/incomplete_works.rake
@@ -10,8 +10,9 @@ namespace :hyku do
       if tenant.blank?
         puts "ERROR: Account tenant name must be provided as an argument"
         puts "Examples:"
-        puts "  rake hyku:incomplete_works[tenant]                  # Run all reports with default row limit"
+        puts "  rake hyku:incomplete_works[tenant]                  # Run all reports with default row limit of 100,000"
         puts "  rake hyku:incomplete_works[tenant,no_files]         # Run only no_files report"
+        puts "  rake hyku:incomplete_works[tenant,no_filesets]      # Run only no_filesets report"
         puts "  rake hyku:incomplete_works[tenant,no_attachments]   # Run only no_attachments report"
         puts "  rake hyku:incomplete_works[tenant,no_files,500]     # Run no_files report with 500 row limit"
         puts "  rake hyku:incomplete_works[tenant,,500]             # Run all reports, each with 500 row limit"
@@ -19,9 +20,8 @@ namespace :hyku do
       end
 
       # Validate report types
-      reports = args[:reports] ? args[:reports].split(',').map(&:to_sym) : %i[no_files no_attachments]
-
-      valid_reports = %i[no_files no_attachments]
+      valid_reports = %i[no_attachments no_filesets no_files]
+      reports = args[:reports] ? args[:reports].split(',').map(&:to_sym) : valid_reports
       invalid_reports = reports - valid_reports
 
       if invalid_reports.any?
@@ -58,7 +58,9 @@ namespace :hyku do
       puts "Check the following files:"
       reports.each do |report|
         case report
-        when :no_files
+          when :no_files
+          puts "  /uploads/filesets_without_files.csv"
+        when :no_filesets
           puts "  /uploads/attachments_without_filesets.csv"
         when :no_attachments
           puts "  /uploads/works_without_attachments.csv"

--- a/lib/tasks/incomplete_works.rake
+++ b/lib/tasks/incomplete_works.rake
@@ -58,7 +58,7 @@ namespace :hyku do
       puts "Check the following files:"
       reports.each do |report|
         case report
-          when :no_files
+        when :no_files
           puts "  /uploads/filesets_without_files.csv"
         when :no_filesets
           puts "  /uploads/attachments_without_filesets.csv"


### PR DESCRIPTION
# Story

Adds a 3rd audit report to the `rake hyku:incomplete_works` task
refs https://github.com/notch8/utk-hyku/issues/765

# Expected Behavior Before Changes

# Expected Behavior After Changes

rake hyku:incomplete_works[tenant]                               # Run all reports with default row limit of 100,000
rake hyku:incomplete_works[tenant,no_files]                 # Run only no_files report
rake hyku:incomplete_works[tenant,no_filesets]            # Run only no_filesets report
rake hyku:incomplete_works[tenant,no_attachments]   # Run only no_attachments report
rake hyku:incomplete_works[tenant,no_files,500]         # Run no_files report with 500 row limit
rake hyku:incomplete_works[tenant,,500]                      # Run all reports, each with 500 row limit

CSV files for the three report runs will be at the following paths:
```
  /uploads/works_without_attachments.csv
  /uploads/attachments_without_filesets.csv
  /uploads/filesets_without_files.csv
```

# Notes