### PR TITLE
add-more-time-for-redis-liveness-prod

### DIFF
--- a/ops/production-deploy.tmpl.yaml
+++ b/ops/production-deploy.tmpl.yaml
@@ -9,12 +9,30 @@ resources:
     cpu: "250m"
 
 livenessProbe:
-  enabled: false
+  enabled: true
+  exec:
+    command:
+      - sh
+      - -c
+      - /health/ping_liveness_local.sh 5
+  initialDelaySeconds: 60       # wait longer before first check
+  periodSeconds: 60             # check every 60s
+  timeoutSeconds: 10            # allow 10s to respond
+  successThreshold: 1
+  failureThreshold: 5           # 5 failures = ~5 mins grace
+
 readinessProbe:
   enabled: true
-  path: "/healthz"
-  periodSeconds: 30
-  timeoutSeconds: 10
+  exec:
+    command:
+      - sh
+      - -c
+      - /health/ping_readiness_local.sh 5
+  initialDelaySeconds: 30     # start earlier than liveness
+  periodSeconds: 60           # check every 60s
+  timeoutSeconds: 10          # allow up to 10s per check
+  successThreshold: 1
+  failureThreshold: 5         # allow 5 failures before marking unready
 
 brandingVolume:
   storageClass: efs-sc

--- a/ops/production-deploy.tmpl.yaml
+++ b/ops/production-deploy.tmpl.yaml
@@ -9,30 +9,12 @@ resources:
     cpu: "250m"
 
 livenessProbe:
-  enabled: true
-  exec:
-    command:
-      - sh
-      - -c
-      - /health/ping_liveness_local.sh 5
-  initialDelaySeconds: 60       # wait longer before first check
-  periodSeconds: 60             # check every 60s
-  timeoutSeconds: 10            # allow 10s to respond
-  successThreshold: 1
-  failureThreshold: 5           # 5 failures = ~5 mins grace
-
+  enabled: false
 readinessProbe:
   enabled: true
-  exec:
-    command:
-      - sh
-      - -c
-      - /health/ping_readiness_local.sh 5
-  initialDelaySeconds: 30     # start earlier than liveness
-  periodSeconds: 60           # check every 60s
-  timeoutSeconds: 10          # allow up to 10s per check
-  successThreshold: 1
-  failureThreshold: 5         # allow 5 failures before marking unready
+  path: "/healthz"
+  periodSeconds: 30
+  timeoutSeconds: 10
 
 brandingVolume:
   storageClass: efs-sc
@@ -258,6 +240,21 @@ redis:
   cluster:
     enabled: false
   password: $REDIS_PASSWORD
+  master:
+    livenessProbe:
+      enabled: true
+      initialDelaySeconds: 60     # wait longer before first check
+      periodSeconds: 60           # check every 60s
+      timeoutSeconds: 10          # allow 10s to respond
+      successThreshold: 1
+      failureThreshold: 5         # 5 failures = ~5 mins grace
+    readinessProbe:
+      enabled: true
+      initialDelaySeconds: 30     # start earlier than liveness
+      periodSeconds: 60           # check every 60s
+      timeoutSeconds: 10          # allow up to 10s per check
+      successThreshold: 1
+      failureThreshold: 5         # allow 5 failures before marking unready
 solr:
   enabled: false
 


### PR DESCRIPTION
### Updates Redis Liveness and Readiness Probe Defaults for Production

**Story**  
During routine cluster maintenance, the Redis workload struggled to come back online. It became stuck in a restart loop, causing `utk` workers to fail due to the inability to connect. Logs indicated that Redis was attempting to read its AOF (append-only file) tail during startup but was restarted prematurely for failing its health checks.

**What This PR Does**  
This PR increases the timing thresholds for Redis health probes, giving Redis more time to finish startup tasks—particularly reading the AOF tail—before being marked unhealthy or unready. This reduces false restarts and improves stability during restarts or upgrades.

---

### Expected Behavior

**Before:**  
- Redis fails to come online during startup.  
- Container restarts repeatedly.  
- `utk` workers crash due to Redis unavailability.

**After:**  
- Redis has sufficient time to load data and report healthy status.  
- Fewer false restarts.  
- `utk` workers can connect once Redis is ready.


</details>

# Notes