### PR TITLE
DO NOT MERGE: hot-patch-21874d2e-add-redis-time-prod-7-20-25

### DIFF
--- a/ops/production-deploy.tmpl.yaml
+++ b/ops/production-deploy.tmpl.yaml
@@ -240,6 +240,21 @@ redis:
   cluster:
     enabled: false
   password: $REDIS_PASSWORD
+  master:
+    livenessProbe:
+      enabled: true
+      initialDelaySeconds: 60     # wait longer before first check
+      periodSeconds: 60           # check every 60s
+      timeoutSeconds: 10          # allow 10s to respond
+      successThreshold: 1
+      failureThreshold: 5         # 5 failures = ~5 mins grace
+    readinessProbe:
+      enabled: true
+      initialDelaySeconds: 30     # start earlier than liveness
+      periodSeconds: 60           # check every 60s
+      timeoutSeconds: 10          # allow up to 10s per check
+      successThreshold: 1
+      failureThreshold: 5         # allow 5 failures before marking unready
 solr:
   enabled: false
 


### PR DESCRIPTION
### Hot Patch: Redis Deployment Fix

This hot patch updates Redis probe values to ensure successful deployment.

It allows us to deploy the current production commit `21874d2e` with the corrected Redis configuration from [PR #779](https://github.com/notch8/utk-hyku/pull/779). That PR will be merged into `main` to persist these changes for future deployments.