### PR TITLE
Serverless IIIF Lambda – Node.js 20 Runtime Upgrade

### DIFF
--- a/ops/production-deploy.tmpl.yaml
+++ b/ops/production-deploy.tmpl.yaml
@@ -82,7 +82,7 @@ extraEnvVars: &envVars
   - name: DB_USER
     value: main
   - name: EXTERNAL_IIIF_URL
-    value: https://wtchtwt5fcxnxj5guruoadqpwm0uvgjl.lambda-url.us-west-2.on.aws/iiif/2
+    value: https://oacfsemyfqrfalk3j4zimxhe3i0tseay.lambda-url.us-west-2.on.aws/iiif/2
   - name: FCREPO_BASE_PATH
     value: /utk-hyku
   - name: FCREPO_HOST


### PR DESCRIPTION
# Story

Refs https://github.com/notch8/dev-ops/issues/874
(UTK-specific follow-up ticket for Serverless IIIF Lambda – Node.js 20 Runtime Upgrade)

# Expected Behavior Before Changes

- UTK deployment was still referencing the old **Node.js 18 runtime**.  
- External IIIF URL was not updated and still pointed to the deprecated Lambda function.  
- AWS Health notifications continued due to outdated runtime usage.  

# Expected Behavior After Changes

- UTK deployment is updated to use the **Node.js 20 runtime**.  
- UTK client environment variable now points to the **new external IIIF URL**:  
- https://oacfsemyfqrfalk3j4zimxhe3i0tseay.lambda-url.us-west-2.on.aws/iiif/2
- Confirmed IIIF sub-URLs resolve properly (example image requests return as expected).  
- Old Lambda function decommissioned, removing AWS Health alerts.  

# Screenshots / Video

<details>
<summary>Example image request before vs. after</summary>

**Before (Node.js 18 – deprecated)**  
`https://wtchtwt5fcxnxj5guruoadqpwm0uvgjl.lambda-url.us-west-2.on.aws/iiif/2/f0b0dc30345737479524077764343fa23775e235/full/!200,200/0/default.jpg`

**After (Node.js 20 – updated)**  
`https://oacfsemyfqrfalk3j4zimxhe3i0tseay.lambda-url.us-west-2.on.aws/iiif/2/f0b0dc30345737479524077764343fa23775e235/full/!200,200/0/default.jpg`

</details>

# Notes

- This PR ensures UTK is aligned with AWS Lambda runtime policy changes before **Node.js 18 EOL (Sept 1, 2025)**.  
- Once merged and deployed, old functions can safely be deleted from the **softserv AWS account**.  
