### PR TITLE
I782 update visibility w jobs

### DIFF
--- a/app/models/concerns/bulkrax/object_factory_interface_decorator.rb
+++ b/app/models/concerns/bulkrax/object_factory_interface_decorator.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# OVERRIDE to account for added Attachment model connecting works to FileSets
+module Bulkrax
+  module ObjectFactoryInterfaceDecorator
+    def update
+      raise "Object doesn't exist" unless object
+      conditionally_destroy_existing_files
+
+      attrs = transform_attributes(update: true)
+      run_callbacks :save do
+        if klass == Bulkrax.collection_model_class
+          update_collection(attrs)
+        elsif klass == Bulkrax.file_model_class
+          update_file_set(attrs)
+        elsif klass == Attachment
+          update_attachment(attrs)
+        else
+          update_work(attrs)
+        end
+      end
+      apply_depositor_metadata
+      log_updated(object)
+    end
+
+    def update_attachment(attrs)
+      work_actor.update(environment(attrs))
+
+      object.file_sets.each do |fs|
+        file_set_attrs = attrs.slice(*fs.attributes.keys)
+        actor = Hyrax::Actors::FileSetOrderedMembersActor.new(fs, @user)
+        actor.attach_to_work(object, file_set_attrs)
+      end
+    end
+  end
+end
+
+Bulkrax::ObjectFactoryInterface.prepend(Bulkrax::ObjectFactoryInterfaceDecorator)

--- a/spec/factories/bulkrax/bulkrax_entries.rb
+++ b/spec/factories/bulkrax/bulkrax_entries.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :bulkrax_csv_entry, class: 'Bulkrax::CsvEntry' do
+    identifier { "csv_entry" }
+    type { 'Bulkrax::CsvEntry' }
+    importerexporter { FactoryBot.build(:bulkrax_importer) }
+    raw_metadata { {} }
+    parsed_metadata { {} }
+  end
+end

--- a/spec/factories/bulkrax/bulkrax_importer_runs.rb
+++ b/spec/factories/bulkrax/bulkrax_importer_runs.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :bulkrax_importer_run, class: 'Bulkrax::ImporterRun' do
+    importer { FactoryBot.build(:bulkrax_importer) }
+    total_work_entries { 1 }
+    enqueued_records { 1 }
+    processed_records { 0 }
+    deleted_records { 0 }
+    failed_records { 0 }
+  end
+end

--- a/spec/factories/bulkrax/bulkrax_importers.rb
+++ b/spec/factories/bulkrax/bulkrax_importers.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :bulkrax_importer, class: 'Bulkrax::Importer' do
+    name { 'CSV Import' }
+    admin_set_id { AdminSet.find_or_create_default_admin_set_id }
+    user { FactoryBot.build(:base_user) }
+    frequency { 'PT0S' }
+    parser_klass { 'Bulkrax::CsvParser' }
+    limit { 10 }
+    parser_fields { { 'import_file_path' => 'spec/fixtures/csv/good.csv' } }
+    field_mapping { Bulkrax.config.field_mappings["Bulkrax::CsvParser"]  }
+    after :create, &:current_run
+
+    trait :with_relationships_mappings do
+      field_mapping do
+        {
+          'parents' => { 'from' => ['parents_column'], split: /\s*[|]\s*/, related_parents_field_mapping: true },
+          'children' => { 'from' => ['children_column'], split: /\s*[|]\s*/, related_children_field_mapping: true }
+        }
+      end
+    end
+  end
+end

--- a/spec/factories/generic_works.rb
+++ b/spec/factories/generic_works.rb
@@ -40,6 +40,21 @@ FactoryBot.define do
       end
     end
 
+    factory :generic_work_with_one_restricted_attachment do
+      title { ["Test GenericWork title"] }
+      after(:build) do |work|
+        work.ordered_members << attachment = FactoryBot.create(
+          :attachment_with_one_file,
+          title: ['Attachment title'],
+          visibility: 'restricted',
+          bulkrax_identifier: "1234-5678"
+        )
+        work.representative = attachment if work.representative_id.blank?
+        work.thumbnail = attachment if work.thumbnail_id.blank?
+        work.save
+      end
+    end
+
     factory :generic_work_with_two_attachments do
       after(:build) do |work|
         work.ordered_members << attachment = FactoryBot.create(

--- a/spec/fixtures/csv/good.csv
+++ b/spec/fixtures/csv/good.csv
@@ -1,0 +1,2 @@
+source_identifier,model,visibility,title
+1234-5678,Attachment,open,"My title"

--- a/spec/models/concerns/bulkrax/import_behavior_decorator_spec.rb
+++ b/spec/models/concerns/bulkrax/import_behavior_decorator_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Bulkrax::ImportBehaviorDecorator, type: :model do
+  let(:entry) do
+    FactoryBot.create(:bulkrax_csv_entry)
+  end
+
+  it 'uses the locally defined methods' do
+    expect(entry.method(:add_rights_statement).owner).to eq(described_class)
+    expect(entry.method(:build_for_importer).owner).to eq(described_class)
+  end
+
+  describe 'updating an attachment' do
+    let(:source_identifier) { "1234-5678" }
+    let(:generic_work) { FactoryBot.create(:generic_work_with_one_restricted_attachment) }
+    let!(:attachment) do
+      generic_work.members
+                  .select { |member| member.is_a? Attachment }
+                  .select { |attachment| attachment.member_of.size == 1 }.first
+    end
+    let(:admin_set_id) { AdminSet.find_or_create_default_admin_set_id }
+    let(:raw_metadata) do
+      { model: 'Attachment', title: "Test title", visibility: 'open', source_identifier: source_identifier }
+    end
+    let(:entry) do
+      FactoryBot.create(:bulkrax_csv_entry,
+                        identifier: source_identifier,
+                        raw_metadata: raw_metadata,
+                        parsed_metadata: {})
+    end
+    let(:last_importer_run) { FactoryBot.create(:bulkrax_importer_run) }
+
+    it 'has the expected visibility' do
+      expect(attachment.visibility).to eq('restricted')
+      expect(attachment.file_sets.first.visibility).to eq('restricted')
+    end
+
+    it 'is updated by the entry' do
+      generic_work
+      expect(attachment.title).to eq(['Attachment title'])
+      expect(attachment.visibility).to eq('restricted')
+      allow(entry.importer).to receive(:last_run).and_return(last_importer_run)
+      rebuilt_attachment = entry.build_for_importer
+      expect(rebuilt_attachment.title).to eq(['Test title'])
+      expect(rebuilt_attachment.visibility).to eq('open')
+      expect(rebuilt_attachment.file_sets.first.visibility).to eq('open')
+    end
+  end
+end

--- a/spec/models/concerns/bulkrax/object_factory_interface_decorator_spec.rb
+++ b/spec/models/concerns/bulkrax/object_factory_interface_decorator_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Bulkrax::ObjectFactoryInterfaceDecorator, type: :model do
+  let(:factory) do
+    Bulkrax.object_factory.new(
+      attributes: attributes,
+      source_identifier_value: "1234-5678",
+      work_identifier: :bulkrax_identifier,
+      work_identifier_search_field: 'bulkrax_identifier_sim',
+      update_files: true,
+      klass: Attachment
+    )
+  end
+  let(:attributes) { {} }
+
+  it 'uses the locally defined methods' do
+    expect(factory.method(:update).owner).to eq(described_class)
+  end
+
+  describe 'updating an Attachment' do
+    let(:generic_work) { FactoryBot.create(:generic_work_with_one_restricted_attachment) }
+    let!(:attachment) do
+      generic_work.members
+                  .select { |member| member.is_a? Attachment }
+                  .select { |attachment| attachment.member_of.size == 1 }.first
+    end
+    let(:attributes) do
+      {
+        "bulkrax_identifier" => "1234-5678",
+        "model" => "Attachment",
+        "title" => ["Test title"],
+        "visibility" => "open",
+        "file" => [],
+        "admin_set_id" => "admin_set/default"
+      }
+    end
+
+    it 'can update an object' do
+      expect(attachment.title).to eq(['Attachment title'])
+      expect(attachment.visibility).to eq('restricted')
+      expect(attachment.file_sets.first.visibility).to eq('restricted')
+      allow(factory).to receive(:find).and_return(attachment)
+      factory.run!
+      expect(attachment.title).to eq(['Test title'])
+      expect(attachment.visibility).to eq('open')
+      expect(attachment.file_sets.first.visibility).to eq('open')
+    end
+  end
+end


### PR DESCRIPTION
# Story
We would like to update a work's FileSet's visibility via Bulkrax
Refs #782

# Expected Behavior Before Changes
Updating the Attachment's visibility does not change the FileSet's visibility, as expected, and in order to update the FileSet's visibility, Bulkrax tries to re-import all the original files, which may not be available.

# Expected Behavior After Changes
When updating the Attachment via Bulkrax, the FileSet's visibility is automatically updated to match that of the Attachment, meaning that the FileSet's visibility does not need to be updated separately.
