### PR TITLE
⚙️ Set workers to 2 in production

### DIFF
--- a/ops/production-deploy.tmpl.yaml
+++ b/ops/production-deploy.tmpl.yaml
@@ -195,7 +195,7 @@ extraEnvVars: &envVars
     value: testing123
 
 worker:
-  replicaCount: 3
+  replicaCount: 2
   resources:
     limits:
       memory: "6Gi"


### PR DESCRIPTION
We were seeing instability with 3 workers and lowering it down to 2 seems to help.  Setting it now in the deploy template.

Ref:
- https://github.com/notch8/utk-hyku/issues/794
