### PR TITLE
Handle no title for no-files report

### DIFF
--- a/app/services/incomplete_works_service.rb
+++ b/app/services/incomplete_works_service.rb
@@ -104,7 +104,7 @@ class IncompleteWorksService
 
     results.map do |hash|
       "https://#{Site.account.cname}/concern/file_sets/#{hash['id']};" \
-      "#{hash['title_tesim'].first};" \
+      "#{hash['title_tesim']&.first};" \
       "#{hash['bulkrax_identifier_tesim']&.first};" \
       "#{hash['import_url_ssim']&.first}"
     end


### PR DESCRIPTION
# Story

Refs https://github.com/notch8/utk-hyku/issues/765

The report fails with an error when there is no title. This commit fixes that situation so the report can run. 
