### PR TITLE
Fix banner image path issue and set HYRAX_UPLOAD_PATH correctly

### DIFF
--- a/ops/friends-deploy.tmpl.yaml
+++ b/ops/friends-deploy.tmpl.yaml
@@ -126,6 +126,8 @@ extraEnvVars: &envVars
     value: good_job
   - name: HYRAX_FITS_PATH
     value: /app/fits/fits.sh
+  - name: HYRAX_UPLOAD_PATH
+    value: "/app/samvera/hyrax-webapp/public/uploads"
   - name: HYRAX_USE_SOLR_GRAPH_NESTING
     value: "true"
   - name: IN_DOCKER

--- a/ops/production-deploy.tmpl.yaml
+++ b/ops/production-deploy.tmpl.yaml
@@ -131,6 +131,8 @@ extraEnvVars: &envVars
     value: good_job
   - name: HYRAX_FITS_PATH
     value: /app/fits/fits.sh
+  - name: HYRAX_UPLOAD_PATH
+    value: "/app/samvera/hyrax-webapp/public/uploads"
   - name: HYRAX_USE_SOLR_GRAPH_NESTING
     value: "true"
   - name: IN_DOCKER


### PR DESCRIPTION
Ref: https://github.com/notch8/utk-hyku/issues/846

## Problem

Homepage banner images were not loading.

The image files exist and are served at:

    /uploads/<tenant>/site/banner_images/...

However, the rendered CSS referenced a filesystem path instead of the public path:

    background-image: url('/app/samvera/uploads/...') → 404

Correct path:

    background-image: url('/uploads/...')

---

## Cause

The Hyrax Helm chart sets:

    HYRAX_UPLOAD_PATH: "/app/samvera/uploads"

when:

    derivativesVolume.enabled = true

This path is **not under `public/`**, so files written there are **not served at `/uploads/`**.

Our infrastructure mounts the uploads volume at:

    public/uploads

Therefore, the application must write uploads there so the **filesystem path and the public URL path align**.

---

## Solution

Set `HYRAX_UPLOAD_PATH` in the deploy values to override the Helm chart default and match our volume mount.

    HYRAX_UPLOAD_PATH: "/app/samvera/hyrax-webapp/public/uploads"

This ensures uploads are written to the location Rails serves at:

    /uploads/

---

## Testing

Manual verification:

1. Deploy with the updated environment variable.
2. Set a banner image in **Admin → Appearance**.
3. Confirm banner images load correctly on:
   - the homepage
   - the Admin appearance preview

---

## Files Changed

- `ops/friends-deploy.tmpl.yaml`
  - add/override `HYRAX_UPLOAD_PATH` to align with Hyku infra volume mounts

- `ops/production-deploy.tmpl.yaml`
  - add/override `HYRAX_UPLOAD_PATH` to align with Hyku infra volume mounts