### PR TITLE
Default to 3 replicas

### DIFF
--- a/ops/friends-deploy.tmpl.yaml
+++ b/ops/friends-deploy.tmpl.yaml
@@ -186,6 +186,8 @@ extraEnvVars: &envVars
     value: admin
   - name: SOLR_COLLECTION_NAME
     value: utk-hyku-friends
+  - name: SOLR_COLLECTION_REPLICAS
+    value: "3"
   - name: SOLR_CONFIGSET_NAME
     value: utk-hyku-friends
   - name: SOLR_HOST

--- a/ops/production-deploy.tmpl.yaml
+++ b/ops/production-deploy.tmpl.yaml
@@ -185,6 +185,8 @@ extraEnvVars: &envVars
     value: admin
   - name: SOLR_COLLECTION_NAME
     value: utk-hyku
+  - name: SOLR_COLLECTION_REPLICAS
+    value: "3"
   - name: SOLR_CONFIGSET_NAME
     value: utk-hyku
   - name: SOLR_HOST


### PR DESCRIPTION
We are now running on 3 Solr pods on both staging and production, which should help stability, availability, and performance. One replica per pod.